### PR TITLE
Restored JDK 7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ branches:
     only:
     - master
     - develop
+    - fix-openjdk7-missing-crypto
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -11,9 +12,13 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 jdk:
-  # - openjdk7 # not passing
+  - openjdk7
   - oraclejdk8
   # - oraclejdk9 # not passing
 before_install:
   - echo $JAVA_HOME
   - chmod +x gradlew
+# Fix missing crypto in openjdk7
+  - sudo wget "https://bouncycastle.org/download/bcprov-ext-jdk15on-158.jar" -O "${JAVA_HOME}/jre/lib/ext/bcprov-ext-jdk15on-158.jar"
+  - sudo perl -pi.bak -e 's/^(security\.provider\.)([0-9]+)/$1.($2+1)/ge' /etc/java-7-openjdk/security/java.security
+  - echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | sudo tee -a /etc/java-7-openjdk/security/java.security

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ version = '1.0'
 description = """chino-java-library"""
 
 sourceCompatibility = 1.7
-targetCompatibility = 1.8
+targetCompatibility = 1.7
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }


### PR DESCRIPTION
# Replaced missing library for testing on Travis-CI
The version of *openjdk7* used in Travis-CI for testing compatibility with Oracle JDK 7 is missing a crypto library.
These changes aim to solve the problem by letting Travis-CI use the BouncyCastle library to build and run the project, as suggested in eddyson-de/tapestry-react#122. Until we cease support for JDK7, this will allow to run tests for the Chino.io Java SDK in Travis-CI for both Java 7 and 8.