### PR TITLE
New feature for **Users**

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ out/
 /nbproject/*
 build.xml
 manifest.mf
-src/test/java/io/chino/java/tmp/
+src/test/java/io/chino/java/replicate_errors/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out/
 /nbproject/*
 build.xml
 manifest.mf
+src/test/java/io/chino/java/tmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: java
 
+
+# NOTE: branch 'develop' is not tested. When a deployable version is ready
+# the commits must be merged into branch 'travis-ci-test' and a build will be
+# triggered automatically. When the build passes, merge the new code into 'master'.
 branches:
     only:
     - master
-#    - develop
+    - travis-ci-test
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -13,27 +17,25 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
-jdk:
-  # tests with 'openjdk7' are run in a stage after passing test with 'oraclejdk8'
-  - oraclejdk8
-
-before_install:
-  - echo $JAVA_HOME
-  - chmod +x gradlew
-
 jobs:
   include:
     - stage: test-jdk8
       jdk: oraclejdk8
+      before_install:
+        - echo $JAVA_HOME
+        - chmod +x gradlew
       script:
         - gradle test --info
     - stage: test-jdk7
       jdk: openjdk7
       if: branch != master
-      script:
+      before_install:
         - sudo wget "https://bouncycastle.org/download/bcprov-ext-jdk15on-158.jar" -O "${JAVA_HOME}/jre/lib/ext/bcprov-ext-jdk15on-158.jar"
         - sudo perl -pi.bak -e 's/^(security\.provider\.)([0-9]+)/$1.($2+1)/ge' /etc/java-7-openjdk/security/java.security
         - echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | sudo tee -a /etc/java-7-openjdk/security/java.security
+        - echo $JAVA_HOME
+        - chmod +x gradlew
+      script:
         - gradle test --info
 stages:
   - test-jdk8

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you're using Maven, then edit your project's "pom.xml" and add this:
 <dependency>
 	<groupId>com.github.chinoio</groupId>
 	    <artifactId>chino-java</artifactId>
-	<version>1.2.2</version>
+	<version>1.2.3</version>
 </dependency>
 ```
 
@@ -33,7 +33,7 @@ allprojects {
 
 dependencies {
     // ...
-    compile 'com.github.chinoio:chino-java:1.2.2'
+    compile 'com.github.chinoio:chino-java:1.2.3'
 }
 ```
 
@@ -134,7 +134,7 @@ You can create an authenticated client, which uses the specified auth method for
 - `new ChinoAPI(<host_url>`
     **non authenticated** - you will need to login.
     
-**New in version 1.2.2**: You can change the auth method with:
+You can change the auth method with:
 
 - `setBearerToken(<bearer_token>)`
 - `setCustomer(<customer_id>, <customer_key>)`
@@ -195,7 +195,11 @@ Class to manage users, `chino.users`
 - `create(<username>, <password>, <attributes>, <user_schema_id>)`
 - `update(<user_id>, <username>, <password>, <attributes>)`
 - `update(<user_id>, <attributes>)`
-    This is for a partial update (for example one attribute)
+    ***WARNING: Deprecated in version 1.2.3*** - This is for a partial update
+    (for example one attribute).
+- `updatePartial(<user_id>, <username>, <password>, <attributes>)`
+    **New in version 1.2.3** update some of the attributes of a User
+- `updatePartial(<user_id>, <attributes>)` **New in version 1.2.3**
 - `delete(<user_id>, <force>)`
     `force` is a boolean and if it's true, the resource cannot be restored
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'io.chino.library'
-version = '1.2.2'
+version = '1.2.3'
 
 description = """chino-java-library"""
 
@@ -31,7 +31,6 @@ buildscript {
 
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.0'
-//        classpath 'com.android.tools.build:gradle:0.5.+'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,4 +47,5 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-core:2.8.1'
     compile 'com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.8.1'
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.8.1'
+    compile 'org.jetbrains:annotations:15.0'
 }

--- a/src/main/java/io/chino/api/user/User.java
+++ b/src/main/java/io/chino/api/user/User.java
@@ -219,4 +219,55 @@ public class User {
 
     	return s;
     }
+
+    /**
+     * Compare this User to another object and tell whether they are equal.
+     * The following conditions will cause this method to return {@code false}:
+     * <ul>
+     *     <li>
+     *         One of the Users represents an updated version of the other,
+     *     </li>
+     *     <li>
+     *         One of the Users has both the userId and the username set to {@code null}
+     *         (the identity of a User can not be verified without those parameters),
+     *     </li>
+     *     <li>
+     *         One of the objects is null.
+     *     </li>
+     * </ul>
+     *
+     * @param obj the {@link Object} to compare
+     * @return {@code true} if the two objects represent the same User object on Chino.io
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this)
+            return true; // same instance
+
+        if (!(obj instanceof User))
+            return false; // obj is null, or is not an instance of class User
+
+        User other = (User) obj;
+        boolean condition;
+        if (userId != null && other.getUserId() != null) {
+            // compare userId
+            condition = other.getUserId().equalsIgnoreCase(userId);
+        } else if (username != null && other.getUsername() != null){
+            // userId is null - compare username
+            condition = other.getUsername().equals(username);
+        } else {
+            // not enough information to tell whether the two Users are the same
+            condition = false;
+        }
+
+        // perform checks on the updated status of the User
+        try {
+            return condition
+                    && other.getInsertDate().equals(insertDate)
+                    && other.getLastUpdate().equals(lastUpdate)
+                    && other.getAttributesAsHashMap().equals(this.getAttributesAsHashMap());
+        } catch (NullPointerException e) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/io/chino/java/Blobs.java
+++ b/src/main/java/io/chino/java/Blobs.java
@@ -32,21 +32,23 @@ public class Blobs extends ChinoBaseAPI {
     }
 
     /**
-     * It uploads an entire File
-     * @param path the path of the file to upload (without the name of the file)
-     * @param documentId the id of the Document to which upload the file
-     * @param field the name of the Field in the Document
-     * @param fileName the name of the file to upload
-     * @return CommitBlobUploadResponse Object which contains the status of the operation
+     * Upload a local file to Chino.io as a BLOB. This method fully handles the upload of a BLOB.
+     *
+     * @param folderPath the path to the folder which contains the local file
+     * @param documentId the id of the Chino.io Document which contains this BLOB
+     * @param field the name of the field (of type "blob") that refers to this BLOB in the Document
+     * @param fileName the name of the local file to upload
+     *
+     * @return A {@link CommitBlobUploadResponse} Object with information about the outcome of the operation
      * @throws IOException
      * @throws ChinoApiException
      */
-    public CommitBlobUploadResponse uploadBlob(String path, String documentId, String field, String fileName) throws IOException, ChinoApiException{
-        checkNotNull(path, "path");
+    public CommitBlobUploadResponse uploadBlob(String folderPath, String documentId, String field, String fileName) throws IOException, ChinoApiException{
+        checkNotNull(folderPath, "path");
         CreateBlobUploadResponse blobResponse = initUpload(documentId, field, fileName);
         String upload_id = blobResponse.getBlob().getUploadId();
 
-        File file = new File(path+File.separator+fileName);
+        File file = new File(folderPath+File.separator+fileName);
         RandomAccessFile raf = new RandomAccessFile(file, "r");
 
         byte[] bytes;
@@ -71,10 +73,11 @@ public class Blobs extends ChinoBaseAPI {
     }
 
     /**
-     * Returns the Blob requested
+     * Returns the requested BLOB
+     *
      * @param blobId the id of the blob to retrieve
      * @param destination the path where to save the file
-     * @return GetBlobResponse Object which contains the Blob Object
+     * @return GetBlobResponse Object which contains the BLOB Object
      * @throws IOException
      * @throws ChinoApiException
      * @throws NoSuchAlgorithmException
@@ -126,11 +129,17 @@ public class Blobs extends ChinoBaseAPI {
 
 
     /**
-     * It initialize the upload
-     * @param documentId the id of the Document to which upload the file
-     * @param field the name of the Field in the Document
+     * Create a BLOB object on Chino.io. This method is called by {@link #uploadBlob(String, String, String, String) uploadBlod()}
+     * and should be <b>never called directly</b>. Its purpose is to initialize the metadata of the file that will be uploaded.
+     *
+     * @see #uploadBlob(String, String, String, String)
+     *
+     * @param documentId the Chino.io ID of the Document the new BLOB belongs to.
+     * @param field the name of the field (with type "blob") in the Document.
      * @param fileName the name of the file to upload
-     * @return CreateBlobUploadResponse Object which contains the upload_id used for the upload of the Blob
+     *
+     * @return a {@link CreateBlobUploadResponse}, which contains the upload_id that is needed for upload the file.
+     *
      * @throws IOException
      * @throws ChinoApiException
      */
@@ -145,12 +154,16 @@ public class Blobs extends ChinoBaseAPI {
     }
 
     /**
-     * It uploads a chunk of data
-     * @param uploadId the upload_id created on the initialization of the upload
-     * @param chunkData an array of bytes that represents a chunk
-     * @param offset the offset of the chunk
+     * Upload a chunk of data to the server. This method is called automatically by {@link #uploadBlob(String, String, String, String) uploadBlob()},
+     * thus should be <b>never called directly</b>.
+     *
+     * @see #uploadBlob(String, String, String, String)
+     *
+     * @param uploadId the upload_id returned by {@link #initUpload(String, String, String) initUpload()}
+     * @param chunkData a chunk of data in the form of a byte array
+     * @param offset the offset of the chunk relative to the beginning of the file
      * @param length the length of the chunk
-     * @return CreateBlobUploadResponse Object which contains the status of the operation
+     * @return A {@link CreateBlobUploadResponse}, which contains the status of the operation
      * @throws IOException
      * @throws ChinoApiException
      */
@@ -163,9 +176,14 @@ public class Blobs extends ChinoBaseAPI {
     }
 
     /**
-     * It does the final commit when all the chunks are uploaded
-     * @param uploadId the upload_id created on the initialization of the upload
-     * @return CommitBlobUploadResponse Object which contains the status of the operation
+     * Confirm and complete the upload on Chino.io.This method is called automatically by {@link #uploadBlob(String, String, String, String) uploadBlob()},
+     * thus should be <b>never called directly</b>.
+     *
+     * @see #uploadBlob(String, String, String, String)
+     *
+     * @param uploadId the upload_id returned by {@link #initUpload(String, String, String) initUpload()}
+     *
+     * @return A {@link CommitBlobUploadResponse}, which contains the status of the operation
      * @throws IOException
      * @throws ChinoApiException
      */
@@ -180,9 +198,10 @@ public class Blobs extends ChinoBaseAPI {
     }
 
     /**
-     * It deletes a Blob
-     * @param blobId the id of the Blob to delete
-     * @param force if true, the resource cannot be restored
+     * Delete a BLOB from Chino.io
+     *
+     * @param blobId the id of the BLOB to delete
+     * @param force if true, the resource cannot be restored. Otherwise, it will only become inactive.
      * @return a String with the result of the operation
      * @throws IOException
      * @throws ChinoApiException

--- a/src/main/java/io/chino/java/ChinoBaseAPI.java
+++ b/src/main/java/io/chino/java/ChinoBaseAPI.java
@@ -1,5 +1,6 @@
 package io.chino.java;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.chino.api.common.*;
 import okhttp3.*;
 import okhttp3.MediaType;
@@ -323,28 +324,38 @@ public class ChinoBaseAPI {
         return fieldsList;
     }
 
-    //Function used to convert a String to a HashMap
-    protected HashMap<String, Object> fromStringToHashMap(String value){
-        checkNotNull(value, "content/attributes");
-        HashMap<String, Object> map = new HashMap<String, Object>();
-        value = value.replaceAll("\\s", "");
-        value = value.replaceAll("\"", "");
-        String[] pairs = value.split(",");
-        for (String pair : pairs) {
-            String[] keyValue = pair.split(":");
-            //To check if it's a digit
-            if(keyValue[1].matches("^-?\\d+$"))
-                map.put(keyValue[0], Integer.parseInt(keyValue[1]));
-                //To check if it is a double
-            else if(keyValue[1].matches("^[-+]?[0-9]*\\.?[0-9]+$"))
-                map.put(keyValue[0], Double.parseDouble(keyValue[1]));
-            else if (keyValue[1].equals("true"))
-                map.put(keyValue[0], true);
-            else if (keyValue[1].equals("false"))
-                map.put(keyValue[0], false);
-            else
-                map.put(keyValue[0], keyValue[1]);
-        }
+//    //Function used to convert a String to a HashMap
+//    protected HashMap<String, Object> fromStringToHashMap(String value){
+//        checkNotNull(value, "content/attributes");
+//        HashMap<String, Object> map = new HashMap<String, Object>();
+//        value = value.replaceAll("\\s", "");
+//        value = value.replaceAll("\"", "");
+//        String[] pairs = value.split(",");
+//        for (String pair : pairs) {
+//            String[] keyValue = pair.split(":");
+//            //To check if it's a digit
+//            if(keyValue[1].matches("^-?\\d+$"))
+//                map.put(keyValue[0], Integer.parseInt(keyValue[1]));
+//                //To check if it is a double
+//            else if(keyValue[1].matches("^[-+]?[0-9]*\\.?[0-9]+$"))
+//                map.put(keyValue[0], Double.parseDouble(keyValue[1]));
+//            else if (keyValue[1].equals("true"))
+//                map.put(keyValue[0], true);
+//            else if (keyValue[1].equals("false"))
+//                map.put(keyValue[0], false);
+//            else
+//                map.put(keyValue[0], keyValue[1]);
+//        }
+//        return map;
+//    }
+
+    protected HashMap<String, Object> fromStringToHashMap(String value) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        //convert JSON string to Map
+        HashMap<String, Object> map = mapper.readValue(
+                value,
+                new TypeReference<HashMap<String, Object>>() {}
+        );
         return map;
     }
 

--- a/src/main/java/io/chino/java/ChinoBaseAPI.java
+++ b/src/main/java/io/chino/java/ChinoBaseAPI.java
@@ -324,31 +324,6 @@ public class ChinoBaseAPI {
         return fieldsList;
     }
 
-//    //Function used to convert a String to a HashMap
-//    protected HashMap<String, Object> fromStringToHashMap(String value){
-//        checkNotNull(value, "content/attributes");
-//        HashMap<String, Object> map = new HashMap<String, Object>();
-//        value = value.replaceAll("\\s", "");
-//        value = value.replaceAll("\"", "");
-//        String[] pairs = value.split(",");
-//        for (String pair : pairs) {
-//            String[] keyValue = pair.split(":");
-//            //To check if it's a digit
-//            if(keyValue[1].matches("^-?\\d+$"))
-//                map.put(keyValue[0], Integer.parseInt(keyValue[1]));
-//                //To check if it is a double
-//            else if(keyValue[1].matches("^[-+]?[0-9]*\\.?[0-9]+$"))
-//                map.put(keyValue[0], Double.parseDouble(keyValue[1]));
-//            else if (keyValue[1].equals("true"))
-//                map.put(keyValue[0], true);
-//            else if (keyValue[1].equals("false"))
-//                map.put(keyValue[0], false);
-//            else
-//                map.put(keyValue[0], keyValue[1]);
-//        }
-//        return map;
-//    }
-
     protected HashMap<String, Object> fromStringToHashMap(String value) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         //convert JSON string to Map

--- a/src/main/java/io/chino/java/Users.java
+++ b/src/main/java/io/chino/java/Users.java
@@ -1,6 +1,7 @@
 package io.chino.java;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.istack.internal.Nullable;
 import io.chino.api.common.ChinoApiConstants;
 import io.chino.api.common.ChinoApiException;
 import io.chino.api.user.CreateUserRequest;
@@ -25,14 +26,18 @@ public class Users extends ChinoBaseAPI {
     }
 
     /**
-     * Returns a list of Users
-     * @param offset the offset from which it retrieves the Users
-     * @param limit number of results (max {@link io.chino.api.common.ChinoApiConstants#QUERY_DEFAULT_LIMIT})
+     * Get the list of Users in a UserSchema
+     *
+     * @param offset the list offset (how many are skipped)
+     * @param limit maximum number of results (must be below {@link io.chino.api.common.ChinoApiConstants#QUERY_DEFAULT_LIMIT ChinoApiConstants.QUERY_DEFAULT_LIMIT})
      * @param userSchemaId the id of the UserSchema
-     * @return GetUsersResponse Object which contains the list of Users
-     * @throws IOException
-     * @throws ChinoApiException
+     *
+     * @return GetUsersResponse Object which contains the list of Users. The list can be retrieved with {@link GetUsersResponse#getUsers()}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
      */
+    @Nullable
     public GetUsersResponse list(String userSchemaId, int offset, int limit) throws IOException, ChinoApiException {
         JsonNode data = getResource("/user_schemas/"+userSchemaId+"/users", offset, limit);
         if(data!=null) {
@@ -43,12 +48,19 @@ public class Users extends ChinoBaseAPI {
     }
 
     /**
-     * Returns a list of Users
+     * Get the list of {@link User Users} in a {@link io.chino.api.userschema.UserSchema UserSchema}. Return the top 100 Users of the list.
+     *
      * @param userSchemaId the id of the UserSchema
-     * @return GetUsersResponse Object which contains the list of Users
-     * @throws IOException
-     * @throws ChinoApiException
+     *
+     * @return GetUsersResponse Object which contains the list of Users. The list can be retrieved with {@link GetUsersResponse#getUsers()}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     *
+     * @see #list(String, int, int)
+     * @see ChinoApiConstants#QUERY_DEFAULT_LIMIT
      */
+    @Nullable
     public GetUsersResponse list(String userSchemaId) throws IOException, ChinoApiException {
         JsonNode data = getResource("/user_schemas/"+userSchemaId+"/users", 0, ChinoApiConstants.QUERY_DEFAULT_LIMIT);
         if(data!=null) {
@@ -59,12 +71,16 @@ public class Users extends ChinoBaseAPI {
     }
 
     /**
-     * It retrieves a specific User
+     * Get the {@link User} object with the matching userId
+     *
      * @param userId the id of the User
-     * @return User Object
-     * @throws IOException
-     * @throws ChinoApiException
+     *
+     * @return the requested User object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
      */
+    @Nullable
     public User read(String userId) throws IOException, ChinoApiException{
         JsonNode data = getResource("/users/"+userId, 0, ChinoApiConstants.QUERY_DEFAULT_LIMIT);
         if(data!=null)
@@ -74,13 +90,18 @@ public class Users extends ChinoBaseAPI {
     }
 
     /**
-     * It retrieves a specific User creating an Object of the class "myClass"
+     * Get the {@link User} object with the matching userId and map its attributes to a new instance of {@code myClass}.
+     * All of the attributes of the User object must be declared in the source of {@code myClass}.
+     *
      * @param userId the id of the User
-     * @param myClass the Class that represents the structure of the User
-     * @return Object of the Class passed as argument
-     * @throws IOException
-     * @throws ChinoApiException
+     * @param myClass the Class that represents the attributes of the User
+     *
+     * @return an instance of {@code myClass} containing the User's attributes.
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
      */
+    @Nullable
     public Object read(String userId, Class myClass) throws IOException, ChinoApiException{
         JsonNode data = getResource("/users/"+userId, 0, ChinoApiConstants.QUERY_DEFAULT_LIMIT);
         if(data!=null){
@@ -92,15 +113,19 @@ public class Users extends ChinoBaseAPI {
     }
 
     /**
-     * It creates a User
-     * @param username the username of the User
-     * @param password the password of the User
-     * @param attributes an HashMap of the attributes
+     * Create a new {@link User} on Chino.io under the specified UserSchema
+     *
+     * @param username the username of the new User
+     * @param password the password of the new User
+     * @param attributes a {@link HashMap} with the attributes of the new User
      * @param userSchemaId the id of the UserSchema
-     * @return User Object
-     * @throws IOException
-     * @throws ChinoApiException
+     *
+     * @return the new {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
      */
+    @Nullable
     public User create(String username, String password, HashMap attributes, String userSchemaId) throws IOException, ChinoApiException {
         CreateUserRequest createUserRequest=new CreateUserRequest(username, password, attributes);
 
@@ -112,15 +137,19 @@ public class Users extends ChinoBaseAPI {
     }
 
     /**
-     * It creates a User
-     * @param username the username of the User
-     * @param password the password of the User
-     * @param attributes a String that represents a json of the attributes
+     * Create a new {@link User} on Chino.io under the specified UserSchema
+     *
+     * @param username the username of the new User
+     * @param password the password of the new User
+     * @param attributes a JSON object (as a {@link String}) with the attributes of the new User
      * @param userSchemaId the id of the UserSchema
-     * @return User Object
-     * @throws IOException
-     * @throws ChinoApiException
+     *
+     * @return the new {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
      */
+    @Nullable
     public User create(String username, String password, String attributes, String userSchemaId) throws IOException, ChinoApiException {
         CreateUserRequest createUserRequest=new CreateUserRequest(username, password, fromStringToHashMap(attributes));
 
@@ -132,17 +161,29 @@ public class Users extends ChinoBaseAPI {
     }
 
     /**
-     * It updates the User
-     * @param userId the id of the User
-     * @param attributes an HashMap with the attributes of the user
-     * @return User Object
-     * @throws IOException
-     * @throws ChinoApiException
+     * Update some fields of a User.
+     *
+     * @param userId the User's ID on Chino.io
+     * @param attributes a {@link HashMap} with the new values of the User's attributes
+     *
+     * @return the updated {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
      */
-    public User update(String userId, HashMap attributes) throws IOException, ChinoApiException {
+    @Nullable
+    public User updatePartial(String userId, HashMap attributes) throws IOException, ChinoApiException {
         checkNotNull(userId, "user_id");
+
         CreateUserRequest createUserRequest= new CreateUserRequest();
+        if (attributes.containsKey("username")) {
+            createUserRequest.setUsername((String) attributes.remove("username"));
+        }
+        if (attributes.containsKey("password")) {
+            createUserRequest.setPassword((String) attributes.remove("password"));
+        }
         createUserRequest.setAttributes(attributes);
+
         JsonNode data = patchResource("/users/"+userId, createUserRequest);
         if(data!=null)
             return mapper.convertValue(data, GetUserResponse.class).getUser();
@@ -151,15 +192,59 @@ public class Users extends ChinoBaseAPI {
     }
 
     /**
-     * It updates a User
-     * @param userId the id of the User
+     * Update some fields of a User.
+     *
+     * @param userId the User's ID on Chino.io
+     * @param attributes a JSON object (as a {@link String}) with the new values of the User's attributes
+     *
+     * @return the updated {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    @Nullable
+    public User updatePartial(String userId, String attributes) throws IOException, ChinoApiException {
+        checkNotNull(userId, "user_id");
+        HashMap attrMap =  fromStringToHashMap(attributes);
+
+        return updatePartial(userId, attrMap);
+    }
+
+    /**
+     * Update some fields of a User.<br>
+     * <br>
+     * <b>WARNING: this method is Deprecated since SDK version 1.2.3</b> and will be removed in a future release.<br>
+     * Please use {@link #updatePartial(String, HashMap)} instead.
+     *
+     * @param userId the User's ID on Chino.io
+     * @param attributes a {@link HashMap} with the new values of the attributes
+     *
+     * @return User Object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    @Deprecated
+    @Nullable
+    public User update(String userId, HashMap attributes) throws IOException, ChinoApiException {
+        return updatePartial(userId, attributes);
+    }
+
+    /**
+     * Update a {@link User} object.
+     *
+     * @param userId the User's ID on Chino.io
      * @param username the username of the User
      * @param password the password of the User
-     * @param attributes an HashMap of the new attributes
-     * @return User Object
-     * @throws IOException
-     * @throws ChinoApiException
+     * @param attributes an HashMap with the new values of the User's attributes.
+     *                   You must provide <b><i> all </i></b> of the attributes that are defined for the User.
+     *
+     * @return the updated {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
      */
+    @Nullable
     public User update(String userId, String username, String password, HashMap attributes) throws IOException, ChinoApiException {
         checkNotNull(userId, "user_id");
         CreateUserRequest createUserRequest= new CreateUserRequest(username, password, attributes);
@@ -172,15 +257,19 @@ public class Users extends ChinoBaseAPI {
     }
 
     /**
-     * It updates a User
-     * @param userId the id of the User
+     * Update a {@link User} object.
+     *
+     * @param userId the User's ID on Chino.io
      * @param username the username of the User
      * @param password the password of the User
-     * @param attributes a String that represents a json of the attributes
-     * @return User Object
-     * @throws IOException
-     * @throws ChinoApiException
+     * @param attributes a JSON object (as a {@link String}) with the new values of the User's attributes
+     *
+     * @return the updated {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
      */
+    @Nullable
     public User update(String userId, String username, String password, String attributes) throws IOException, ChinoApiException {
         checkNotNull(userId, "user_id");
         CreateUserRequest createUserRequest= new CreateUserRequest(username, password, fromStringToHashMap(attributes));
@@ -193,12 +282,16 @@ public class Users extends ChinoBaseAPI {
     }
 
     /**
-     * It deletes a User
-     * @param userId the id of the User
-     * @param force if true, the resource cannot be restored
-     * @return a String with the result of the operation
-     * @throws IOException
-     * @throws ChinoApiException
+     * Delete a {@link User} object
+     *
+     * @param userId the User's ID on Chino.io
+     * @param force set to {@code false} to deactivate the User; set to {@code true} to delete it.
+     *              Deleted objects are lost forever.
+     *
+     * @return a String with the result of the operation (either {@code "success"} or an error message)
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
      */
     public String delete(String userId, boolean force) throws IOException, ChinoApiException {
         checkNotNull(userId, "user_id");

--- a/src/main/java/io/chino/java/Users.java
+++ b/src/main/java/io/chino/java/Users.java
@@ -1,13 +1,13 @@
 package io.chino.java;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.sun.istack.internal.Nullable;
 import io.chino.api.common.ChinoApiConstants;
 import io.chino.api.common.ChinoApiException;
 import io.chino.api.user.CreateUserRequest;
 import io.chino.api.user.GetUserResponse;
 import io.chino.api.user.GetUsersResponse;
 import io.chino.api.user.User;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/src/test/java/io/chino/java/BlobsTest.java
+++ b/src/test/java/io/chino/java/BlobsTest.java
@@ -1,0 +1,59 @@
+package io.chino.java;
+
+import io.chino.api.common.Field;
+import io.chino.api.document.Document;
+import io.chino.api.userschema.UserSchemaStructure;
+import io.chino.java.testutils.ChinoBaseTest;
+import io.chino.java.testutils.TestConstants;
+import org.junit.*;
+
+import java.util.LinkedList;
+
+import static org.junit.Assert.*;
+
+public class BlobsTest extends ChinoBaseTest {
+
+    ChinoAPI chino_customer;
+    Blobs test;
+
+    static String repoID, schemaID;
+    Document owner;
+
+    @BeforeClass
+    public void setUpClass() throws Exception {
+        chino_customer = new ChinoAPI(TestConstants.HOST, TestConstants.CUSTOMER_ID, TestConstants.CUSTOMER_KEY);
+        test = (Blobs) ChinoBaseTest.init(chino_customer.blobs);
+        ChinoBaseTest.beforeClass();
+
+        repoID = chino_customer.repositories.create("BlobsTest").getRepositoryId();
+        LinkedList<Field> fields = new LinkedList<>();
+        UserSchemaStructure s = new UserSchemaStructure();
+        schemaID = chino_customer.schemas.create(repoID, "This schema is used for Documents that store BLOBs in  BlobsTest");
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        owner = chino_customer.documents.create()
+    }
+
+    @Test
+    public void uploadBlob() {
+    }
+
+    @Test
+    public void get() {
+    }
+
+    @Test
+    public void delete() {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @AfterClass
+    public void tearDownClass() throws Exception {
+        ChinoBaseTest.afterClass();
+    }
+}

--- a/src/test/java/io/chino/java/BlobsTest.java
+++ b/src/test/java/io/chino/java/BlobsTest.java
@@ -2,6 +2,7 @@ package io.chino.java;
 
 import io.chino.api.common.Field;
 import io.chino.api.document.Document;
+import io.chino.api.schema.SchemaStructure;
 import io.chino.api.userschema.UserSchemaStructure;
 import io.chino.java.testutils.ChinoBaseTest;
 import io.chino.java.testutils.TestConstants;
@@ -11,6 +12,9 @@ import java.util.LinkedList;
 
 import static org.junit.Assert.*;
 
+/**
+ *  (Work in progress)
+ */
 public class BlobsTest extends ChinoBaseTest {
 
     ChinoAPI chino_customer;
@@ -19,7 +23,7 @@ public class BlobsTest extends ChinoBaseTest {
     static String repoID, schemaID;
     Document owner;
 
-    @BeforeClass
+    // @BeforeClass
     public void setUpClass() throws Exception {
         chino_customer = new ChinoAPI(TestConstants.HOST, TestConstants.CUSTOMER_ID, TestConstants.CUSTOMER_KEY);
         test = (Blobs) ChinoBaseTest.init(chino_customer.blobs);
@@ -27,32 +31,33 @@ public class BlobsTest extends ChinoBaseTest {
 
         repoID = chino_customer.repositories.create("BlobsTest").getRepositoryId();
         LinkedList<Field> fields = new LinkedList<>();
-        UserSchemaStructure s = new UserSchemaStructure();
-        schemaID = chino_customer.schemas.create(repoID, "This schema is used for Documents that store BLOBs in  BlobsTest");
+        SchemaStructure s = new SchemaStructure();
+        s.setFields(fields);
+        schemaID = chino_customer.schemas.create(repoID, "This schema is used for Documents that store BLOBs in BlobsTest", s).getSchemaId();
     }
 
-    @Before
+    // @Before
     public void setUp() throws Exception {
-        owner = chino_customer.documents.create()
+//        owner = chino_customer.documents.create()
     }
 
-    @Test
+    // @Test
     public void uploadBlob() {
     }
 
-    @Test
+    // @Test
     public void get() {
     }
 
-    @Test
+    // @Test
     public void delete() {
     }
 
-    @After
+    // @After
     public void tearDown() throws Exception {
     }
 
-    @AfterClass
+    // @AfterClass
     public void tearDownClass() throws Exception {
         ChinoBaseTest.afterClass();
     }

--- a/src/test/java/io/chino/java/UsersTest.java
+++ b/src/test/java/io/chino/java/UsersTest.java
@@ -1,0 +1,267 @@
+package io.chino.java;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.chino.api.application.Application;
+import io.chino.api.application.ClientType;
+import io.chino.api.common.ChinoApiException;
+import io.chino.api.user.User;
+import io.chino.api.userschema.UserSchema;
+import io.chino.java.testutils.ChinoBaseTest;
+import io.chino.java.testutils.DeleteAll;
+import io.chino.java.testutils.TestConstants;
+import io.chino.java.testutils.UserSchemaStructureSample;
+import org.junit.*;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+
+import static org.junit.Assert.*;
+
+public class UsersTest extends ChinoBaseTest {
+
+    private static final String PWD = "defaultPwd";
+    private static ChinoAPI chino_admin;
+    private static Users test;
+
+    private static UserSchema userSchema;
+    private static SimpleDateFormat dateFormat = new SimpleDateFormat("YYYY-MM-dd");
+
+    private static final int MAX_USERS = 10;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        ChinoBaseTest.beforeClass();
+        chino_admin = new ChinoAPI(TestConstants.HOST, TestConstants.CUSTOMER_ID, TestConstants.CUSTOMER_KEY);
+        test = (Users) ChinoBaseTest.init(chino_admin.users);
+
+        ChinoBaseTest.checkResourceIsEmpty(
+                chino_admin.userSchemas.list().getUserSchemas().isEmpty(),
+                chino_admin.userSchemas
+        );
+
+        try {
+            userSchema = chino_admin.userSchemas.create("Test UserSchema for class UsersTest", UserSchemaStructureSample.class);
+        } catch (Exception ex) {
+            fail("failed to set up test for UsersTest (create UserSchema).\n"
+                    + ex.getClass().getSimpleName() + ": " + ex.getMessage());
+        }
+    }
+
+    @Before
+    public void setUp() throws IOException, ChinoApiException {
+        new DeleteAll().deleteAll(test);
+    }
+
+    @Test
+    public void listTest() throws IOException, ChinoApiException {
+        LinkedList<User> localUsers = new LinkedList<>();
+        for (int i = 0; i < MAX_USERS; i++) {
+                localUsers.add(
+                        newUser("listTest_" + i)
+                );
+        }
+        /* LIST 1 params */
+        LinkedList<User> fetchedUsers = new LinkedList<>(
+                test.list(userSchema.getUserSchemaId()).getUsers()
+        );
+        // check that MAX_USERS users are retrieved
+        assertEquals("unexpected size of the fetched Users list", MAX_USERS, fetchedUsers.size());
+
+        int missing = 0;
+        StringBuilder missingUsers = new StringBuilder();
+        for (User u : localUsers) {
+            if (! fetchedUsers.contains(u)) {
+                missing ++;
+                missingUsers.append("\t" + (++ missing) + ". ").append(u.getUsername()).append("\n");
+            }
+        }
+        // check that all created users are retrieved
+        assertEquals(missing + " Users missing: \n" + missingUsers.toString(), 0, missing);
+
+        /* LIST 3 params - offset */
+        int offset = MAX_USERS / 2;
+        fetchedUsers = new LinkedList<>(
+                test.list(userSchema.getUserSchemaId(), offset, MAX_USERS).getUsers()
+        );
+        // check that (MAX_USERS - offset) users are retrieved
+        assertEquals("unexpected size of the fetched Users list (OFFSET = " + offset + ")", MAX_USERS - offset, fetchedUsers.size());
+
+        missing = 0;
+        missingUsers = new StringBuilder();
+        for (User u : fetchedUsers) {
+            if (! localUsers.contains(u)) {
+                missing ++;
+                missingUsers.append("\t" + (++ missing) + ". ").append(u.getUsername()).append("\n");
+            }
+        }
+        // check that all fetched users are in the local list
+        assertEquals(missing + " Users missing: \n" + missingUsers.toString(), 0, missing);
+
+        /* LIST 3 params - limit */
+        int limit = 1;
+        fetchedUsers = new LinkedList<>(
+                test.list(userSchema.getUserSchemaId(), MAX_USERS - 1, limit).getUsers()
+        );
+        // check that 1 user was retrieved and that it's in the local list
+        assertEquals("unexpected size of the fetched Users list (LIMIT = " + limit + ")", 1, fetchedUsers.size());
+        assertTrue(localUsers.contains(fetchedUsers.get(0)));
+    }
+
+    @Test
+    public void createAndReadTest() throws IOException, ChinoApiException {
+        UserSchemaStructureSample attr = new UserSchemaStructureSample("readTest");
+        attr.test_integer = 42;
+        /* CREATE - attrs passed as JSON String*/
+        User local = newUser("createAndReadTest_1 (attributes as String)", attr);
+
+        /* READ 1 params */
+        User fetched = test.read(local.getUserId());
+        assertEquals("Read user is different from local.", local, fetched);
+
+        /* CREATE - attrs passed as HashMap */
+        String testName = "test String - createAndReadTest_2 (attributes as HashMap)";
+        HashMap<String, Object> attrMap = new HashMap<>();
+        attrMap.put("test_integer", 42);
+        attrMap.put("test_boolean", true);
+        attrMap.put("test_float", (float) 0.987);
+        attrMap.put("test_string", testName);
+
+        attrMap.put("test_date", dateFormat.format(new Date()));
+
+        local = test.create(  "createAndReadTest_2_user@test.chino.io", "defaultPwd", attrMap, userSchema.getUserSchemaId());
+
+        /* READ 2 params */
+        UserSchemaStructureSample fetchedAttr = (UserSchemaStructureSample) test.read(local.getUserId(), UserSchemaStructureSample.class);
+
+        assertEquals("Read user has different int attribute from local", attr.test_integer, fetchedAttr.test_integer);
+        assertEquals("Read user has different String attribute from local", testName, fetchedAttr.test_string);
+    }
+
+    @Test
+    public void updatePartial_HashMap() throws IOException, ChinoApiException {
+        User old = newUser("updatePartial_HashMap");
+
+        UserSchemaStructureSample oldAttrs = (UserSchemaStructureSample) test.read(old.getUserId(), UserSchemaStructureSample.class);
+        UserSchemaStructureSample newAttrs = new UserSchemaStructureSample(oldAttrs);
+        newAttrs.test_integer ++;
+
+        String newUsername = "UPDATED_" + old.getUsername(),
+                newPassword = "updatedPW";
+
+        HashMap<String, Object> updatedAttributes = new HashMap<>();
+        updatedAttributes.put("test_integer", newAttrs.test_integer);
+
+        updatedAttributes.put("username", newUsername);
+        updatedAttributes.put("password", newPassword);
+
+        User updated = test.updatePartial(old.getUserId(), updatedAttributes);
+
+        assertEquals(old.getUserId(), updated.getUserId());
+        assertEquals("user not updated!", newAttrs.test_integer, updated.getAttributesAsHashMap().get("test_integer"));
+        assertNotEquals("user not updated!", old.getUsername(), updated.getUsername());
+
+        // verify that login is enabled with new credentials
+        Application app = chino_admin.applications.create("test Application for UsersTest", "password", "", ClientType.PUBLIC);
+        try {
+            ChinoAPI appClient = new ChinoAPI(TestConstants.HOST);
+            appClient.setBearerToken(
+                    appClient.auth.loginWithPassword(newUsername, newPassword, app.getAppId()).getAccessToken()
+            );
+        } finally {
+            chino_admin.applications.delete(app.getAppId(), true);
+        }
+    }
+
+    @Test
+    public void updatePartial_String() throws IOException, ChinoApiException {
+        User old = newUser("updatePartial_String");
+        UserSchemaStructureSample oldAttrs = (UserSchemaStructureSample) test.read(old.getUserId(), UserSchemaStructureSample.class);
+        UserSchemaStructureSample newAttrs = new UserSchemaStructureSample(oldAttrs);
+        newAttrs.test_integer ++;
+
+        String updatedAttributes = "{" +
+                "  \"test_integer\":" + newAttrs.test_integer +
+                "}";
+        User updated = test.updatePartial(old.getUserId(), updatedAttributes);
+
+        assertNotNull("user not updated!", updated);
+        assertEquals("user not updated!", newAttrs.test_integer, updated.getAttributesAsHashMap().get("test_integer"));
+    }
+
+    @Test
+    public void updateTest_HashMap() throws IOException, ChinoApiException {
+        User old = newUser("updateTest_HashMap");
+        UserSchemaStructureSample oldAttrs = (UserSchemaStructureSample) test.read(old.getUserId(), UserSchemaStructureSample.class);
+        UserSchemaStructureSample newAttrs = new UserSchemaStructureSample(oldAttrs);
+
+        HashMap<String, Object> updatedAttributes = new HashMap<>();
+        updatedAttributes.put("test_integer", ++ newAttrs.test_integer);
+        updatedAttributes.put("test_boolean", newAttrs.test_boolean);
+        updatedAttributes.put("test_date", dateFormat.format(newAttrs.test_date));
+        updatedAttributes.put("test_float", newAttrs.test_float);
+        updatedAttributes.put("test_string", "updateTest_HashMap_updated");
+
+        User updated = test.update(old.getUserId(), old.getUsername(), TestConstants.PASSWORD, updatedAttributes);
+
+        assertNotNull("user not updated!", updated);
+        assertEquals("user not updated!", newAttrs.test_integer, updated.getAttributesAsHashMap().get("test_integer"));
+
+    }
+
+    @Test
+    public void updateTest_String() throws IOException, ChinoApiException {
+        User old = newUser("updatePartial_String");
+        UserSchemaStructureSample oldAttrs = (UserSchemaStructureSample) test.read(old.getUserId(), UserSchemaStructureSample.class);
+        UserSchemaStructureSample newAttrs = new UserSchemaStructureSample(oldAttrs);
+        newAttrs.test_integer ++;
+
+        String updatedAttributes = new ObjectMapper().writeValueAsString(newAttrs);
+
+        User updated = test.update(old.getUserId(), old.getUsername(), TestConstants.PASSWORD, updatedAttributes);
+
+        assertNotNull("user not updated!", updated);
+        assertEquals("user not updated!", newAttrs.test_integer, updated.getAttributesAsHashMap().get("test_integer"));
+    }
+
+    @Test
+    public void deleteTest() throws IOException, ChinoApiException {
+        User user = newUser("deleteTest");
+
+        test.delete(user.getUserId(), false);
+
+        user = test.read(user.getUserId());
+        assertFalse("User is active", user.getIsActive());
+
+        test.delete(user.getUserId(), true);
+
+        try {
+            user = test.read(user.getUserId());
+            fail("The user was not deleted");
+        } catch (ChinoApiException e) {
+            assertEquals("Unexpected error when attempting to read deleted user: " + e.getCode(), "404", e.getCode());
+        }
+    }
+
+    /**
+     * Utility method to create a new User with custom attributes
+     *
+     */
+    private User newUser(String testName, UserSchemaStructureSample customAttrs) throws IOException, ChinoApiException {
+        String attrs = new ObjectMapper().writeValueAsString(customAttrs);
+        String username = testName.trim().split(" ")[0];
+        return test.create(username + "_user@test.chino.io", TestConstants.PASSWORD, attrs, userSchema.getUserSchemaId());
+    }
+
+    /**
+     * Utility method to create a new User with default attributes
+     *
+     */
+    private User newUser(String testName) throws IOException, ChinoApiException {
+        UserSchemaStructureSample userAttributes = new UserSchemaStructureSample(testName);
+
+        return newUser(testName, userAttributes);
+    }
+}

--- a/src/test/java/io/chino/java/testutils/ChinoBaseTest.java
+++ b/src/test/java/io/chino/java/testutils/ChinoBaseTest.java
@@ -75,14 +75,20 @@ public class ChinoBaseTest {
     /**
      * Handles test interruption when there are instances of a Chino.io resource
      * on the customer's Chino.io API account. If {@link TestConstants#FORCE_DELETE_ALL_ON_TESTS} is
-     * set to {@code true}, the test won't be interrupted and all the objects on the Chino.io account will be deleted.
+     * set to {@code true}, the test won't be interrupted and all the objects on the Chino.io account will be deleted.<br>
+     * <br>
+     * Example:<br><br>
+     * <code>
+     *     ChinoAPI chinoApi = new ChinoAPI(HOST, CUSTOMER_ID, CUSTOMER_KEY);<br>
+     *     checkResourceIsEmpty(chinoApi.userSchemas.list().getUserSchemas.isEmpty(), chinoApi.userSchemas);
+     * </code>
      *
      * @param resourceIsEmpty the result of {@link List#isEmpty()} or another value, which should be {@code true}
      *                        only if there are no resources of the desired type stored on Chino.io.
      * @param resourceAPIClient the API client that will be eventually used to delete all the objects of that kind if
      * {@link TestConstants#FORCE_DELETE_ALL_ON_TESTS} is set to {@code true}.
      */
-    protected static final void checkResourceIsEmpty(boolean resourceIsEmpty, ChinoBaseAPI resourceAPIClient) throws IOException, ChinoApiException {
+    protected static void checkResourceIsEmpty(boolean resourceIsEmpty, ChinoBaseAPI resourceAPIClient) throws IOException, ChinoApiException {
         String resourceName = resourceAPIClient.getClass().getSimpleName();
 
         if (! resourceIsEmpty) {

--- a/src/test/java/io/chino/java/testutils/ChinoBaseTest.java
+++ b/src/test/java/io/chino/java/testutils/ChinoBaseTest.java
@@ -23,14 +23,8 @@ public class ChinoBaseTest {
 
     private static ChinoBaseAPI test = null;
 
-    static boolean continueTests = true;
+    protected static boolean continueTests = true;
     static String errorMsg = "init() method not called";
-
-    static {
-        TestConstants.init(USERNAME, PASSWORD);
-        if (Objects.equals(System.getenv("automated_test"), "allow")) // null-safe 'equals()'
-            TestConstants.FORCE_DELETE_ALL_ON_TESTS = true;
-    }
 
 
     /**
@@ -40,6 +34,7 @@ public class ChinoBaseTest {
      * @return the API client that has been set for this instance
      */
     public static ChinoBaseAPI init(ChinoBaseAPI testedAPIClient) {
+
         errorMsg = "no errors";
         test = testedAPIClient;
 
@@ -47,7 +42,11 @@ public class ChinoBaseTest {
     }
 
     @BeforeClass
-    public static void beforeClass() throws IOException, ChinoApiException {}
+    public static void beforeClass() throws IOException, ChinoApiException {
+        TestConstants.init(USERNAME, PASSWORD);
+        if (Objects.equals(System.getenv("automated_test"), "allow")) // null-safe 'equals()'
+            TestConstants.FORCE_DELETE_ALL_ON_TESTS = true;
+    }
 
     @Before
     public void before() {
@@ -69,6 +68,7 @@ public class ChinoBaseTest {
         errorMsg =  "init() method not called";
         continueTests = true;
         test = null;
+        System.gc();
     }
 
 
@@ -94,7 +94,7 @@ public class ChinoBaseTest {
         if (! resourceIsEmpty) {
             if (! TestConstants.FORCE_DELETE_ALL_ON_TESTS) {
             Scanner scanner = new Scanner(System.in);
-            System.err.println("WARNING: this account has" + resourceName + "stored. If you run the tests they will be deleted.");
+            System.err.println("WARNING: this account has " + resourceName + " stored. If you run the tests they will be deleted.");
             System.err.println("To hide this message, set the constant TestConstants.FORCE_DELETE_ALL_ON_TESTS to 'true' and re-run the tests.");
             } else {
                 System.out.println("TestConstants.FORCE_DELETE_ALL_ON_TESTS = true");

--- a/src/test/java/io/chino/java/testutils/UserSchemaStructureSample.java
+++ b/src/test/java/io/chino/java/testutils/UserSchemaStructureSample.java
@@ -1,11 +1,44 @@
 package io.chino.java.testutils;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Date;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class UserSchemaStructureSample {
+
+    @JsonProperty("test_integer")
     public int test_integer;
+    @JsonProperty("test_string")
     public String test_string;
+    @JsonProperty("test_boolean")
     public boolean test_boolean;
+    @JsonProperty("test_date")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "YYYY-MM-dd")
     public Date test_date;
+    @JsonProperty("test_float")
     public float test_float;
+
+    private UserSchemaStructureSample() {
+    }
+
+    public UserSchemaStructureSample(String testName) {
+        String suffix = (testName == null || testName.isEmpty()) ? "" : " - " + testName;
+
+        this.test_boolean = true;
+        this.test_date = new Date();
+        this.test_float = (float) 0.987;
+        this.test_integer = 1234;
+        this.test_string = "test String" + suffix;
+    }
+
+    public UserSchemaStructureSample(UserSchemaStructureSample copyFrom) {
+        this.test_boolean = copyFrom.test_boolean;
+        this.test_date = copyFrom.test_date;
+        this.test_float = copyFrom.test_float;
+        this.test_integer = copyFrom.test_integer;
+        this.test_string = copyFrom.test_string;
+    }
 }


### PR DESCRIPTION
# New feature for **Users** API client
## Changelog:
* **Deprecated method `update(String, HashMap)`** - will be removed in a future release 
* Added `updatePartial` methods to update only some fields of a User:
    * `updatePartial(String, String, String, HashMap)`
    * `updatePartial(String, String, String, String)` (which allows to pass the attributes as a JSON String instead of a HasMap)
* Improved documentation of class `io.chino.java.Users`
* Minor fixes and improvements