### PR TITLE
check host URL of ChinoAPI

### DIFF
--- a/src/main/java/io/chino/java/ChinoAPI.java
+++ b/src/main/java/io/chino/java/ChinoAPI.java
@@ -32,14 +32,17 @@ public class ChinoAPI {
      * @param customerId the customer id provided by Chino.io
      * @param customerKey the customer key provided by Chino.io
      */
-    public ChinoAPI(String hostUrl, String customerId, String customerKey){
+    public ChinoAPI(String hostUrl, String customerId, String customerKey) {
         checkNotNull(hostUrl, "host_url");
         checkNotNull(customerId, "customer_id");
         checkNotNull(customerKey, "customer_key");
         client = getDefaultHttpClient()
                 .addNetworkInterceptor(new LoggingInterceptor(customerId, customerKey))
                 .build();
-        initObjects(hostUrl.replace("http://", "https://"));
+        if (hostUrl.startsWith("http://")) {
+            hostUrl = hostUrl.replace("http://", "https://");
+        }
+        initObjects(hostUrl);
     }
 
     /**

--- a/src/main/java/io/chino/java/ChinoAPI.java
+++ b/src/main/java/io/chino/java/ChinoAPI.java
@@ -46,7 +46,7 @@ public class ChinoAPI {
         client = getDefaultHttpClient()
                 .addNetworkInterceptor(new LoggingInterceptor(customerId, customerKey))
                 .build();
-        initObjects(normalizeApiUrl(hostUrl));
+        initObjects(hostUrl);
     }
 
     /**
@@ -79,6 +79,7 @@ public class ChinoAPI {
     }
     
     private void initObjects(String hostUrl){
+        hostUrl = normalizeApiUrl(hostUrl);
         applications = new Applications(hostUrl, this);
         userSchemas = new UserSchemas(hostUrl, this);
         documents = new Documents(hostUrl, this);

--- a/src/main/java/io/chino/java/ChinoAPI.java
+++ b/src/main/java/io/chino/java/ChinoAPI.java
@@ -117,11 +117,15 @@ public class ChinoAPI {
             // remove trailing '/' (if any) and return URL
             return hostUrl.replace(API_VERSION + "/", API_VERSION);
         } else {
-            // append API version code and return URL
-            if (! hostUrl.endsWith("/")) {
-                hostUrl += "/";
+            String errString = "Chino API version not specified. Allowed values: %s";
+            StringBuilder versions = new StringBuilder("[");
+            for (String v : getAvailableVersions()) {
+                versions.append("\"").append(v).append("\"");
             }
-            return hostUrl + API_VERSION;
+            versions.append("]");
+            throw new IllegalArgumentException(
+                    String.format(errString, versions.toString())
+            );
         }
     }
 
@@ -189,7 +193,7 @@ public class ChinoAPI {
      *
      * @return a {@link List List<String>} with the supported version codes
      */
-    public List<String> getAvailableVersions() {
+    public static List<String> getAvailableVersions() {
         return java.util.Collections.singletonList(API_VERSION);
     }
 }

--- a/src/test/java/io/chino/java/RepositoriesTest.java
+++ b/src/test/java/io/chino/java/RepositoriesTest.java
@@ -63,12 +63,12 @@ public class RepositoriesTest extends ChinoBaseTest {
     @Test
     public void test_list() throws IOException, ChinoApiException {
         Repository[] repos = new Repository[5];
-        synchronized (test) {
+        synchronized (this) {
             for (int i=0; i<5; i++) {
                 repos[i] = test.create("test_list_repo" + i);
                 try {
                     wait(3000);
-                } catch (InterruptedException ignored) {}
+                } catch (InterruptedException | IllegalMonitorStateException ignored) {}
             }
         }
 

--- a/src/test/res/test.properties
+++ b/src/test/res/test.properties
@@ -2,8 +2,8 @@
 
 #chino.test.customer_id=
 #chino.test.customer_key=
-## set to 'allow' to enable testing.
-## WARNING: this allows the test suite to delete everything from the test host.
+# set 'chino.test.automated=allow' to enable testing.
+## WARNING: this allows the test suite to delete everything on the account in 'host'.
 #chino.test.automated=
 ## default value: https://api.test.chino.io/v1
 #chino.test.host=


### PR DESCRIPTION
Now checking the host Url of Chino API.
When creating a `ChinoAPI` client, the following checks are made:

* URL contains the version code `/v1` (if not, throws `IllegalArgumentException`)
* URL does not end with `/` (no errors, the trailing slash is removed)