### PR TITLE
Improved activation/deactivation of resources

### DIFF
--- a/src/main/java/io/chino/api/collection/CreateCollectionRequest.java
+++ b/src/main/java/io/chino/api/collection/CreateCollectionRequest.java
@@ -4,12 +4,13 @@ package io.chino.api.collection;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.chino.api.common.ActivationRequest;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
         "name",
 })
-public class CreateCollectionRequest {
+public class CreateCollectionRequest extends ActivationRequest {
 
     @JsonProperty("name")
     private String name;

--- a/src/main/java/io/chino/api/common/ActivationRequest.java
+++ b/src/main/java/io/chino/api/common/ActivationRequest.java
@@ -22,4 +22,8 @@ public abstract class ActivationRequest {
     public Boolean isActive() {
         return isActive ? true : null;
     }
+
+    public void resetActivationStatus() {
+        isActive = false;
+    }
 }

--- a/src/main/java/io/chino/api/common/ActivationRequest.java
+++ b/src/main/java/io/chino/api/common/ActivationRequest.java
@@ -7,16 +7,21 @@ public abstract class ActivationRequest {
     private boolean mustActivate = false;
 
     /**
-     * This method must be invoked during an update() API call.<br>
-     * When this class is serialized with an {@link com.fasterxml.jackson.databind.ObjectMapper},
-     * this class will contain an additional field<br>
-     * <br>
-     * {@code "is_active": true}
+     * This method is invoked in the {@code update(boolean, ...)} API call.<br>
+     * It will set {@code "is_active": true} in the update request.
      */
     public void activateResource() {
         mustActivate = true;
     }
 
+    /**
+     * This method is invoked during serialization with {@link com.fasterxml.jackson.databind.ObjectMapper}.
+     * If {@link #activateResource()} was called, the serializer will receive "true" and set {@code "is_active": true},
+     * otherwise it will receive "null" and ignore this parameter.
+     *
+     * @return {@code true} if {@link #activateResource()} was called on this {@link ActivationRequest},
+     * otherwise {@code null}
+     */
     @JsonGetter("is_active")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Boolean isActive() {

--- a/src/main/java/io/chino/api/common/ActivationRequest.java
+++ b/src/main/java/io/chino/api/common/ActivationRequest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 public abstract class ActivationRequest {
-    private boolean isActive = false;
+    private boolean mustActivate = false;
 
     /**
      * This method must be invoked during an update() API call.<br>
@@ -14,16 +14,16 @@ public abstract class ActivationRequest {
      * {@code "is_active": true}
      */
     public void activateResource() {
-        isActive = true;
+        mustActivate = true;
     }
 
     @JsonGetter("is_active")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Boolean isActive() {
-        return isActive ? true : null;
+        return mustActivate ? true : null;
     }
 
     public void resetActivationStatus() {
-        isActive = false;
+        mustActivate = false;
     }
 }

--- a/src/main/java/io/chino/api/common/ActivationRequest.java
+++ b/src/main/java/io/chino/api/common/ActivationRequest.java
@@ -1,0 +1,25 @@
+package io.chino.api.common;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public abstract class ActivationRequest {
+    private boolean isActive = false;
+
+    /**
+     * This method must be invoked during an update() API call.<br>
+     * When this class is serialized with an {@link com.fasterxml.jackson.databind.ObjectMapper},
+     * this class will contain an additional field<br>
+     * <br>
+     * {@code "is_active": true}
+     */
+    public void activateResource() {
+        isActive = true;
+    }
+
+    @JsonGetter("is_active")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean isActive() {
+        return isActive ? true : null;
+    }
+}

--- a/src/main/java/io/chino/api/document/CreateDocumentRequest.java
+++ b/src/main/java/io/chino/api/document/CreateDocumentRequest.java
@@ -4,6 +4,7 @@ package io.chino.api.document;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.chino.api.common.ActivationRequest;
 
 import java.util.HashMap;
 
@@ -11,7 +12,7 @@ import java.util.HashMap;
 @JsonPropertyOrder({
     "content"
 })
-public class CreateDocumentRequest {
+public class CreateDocumentRequest extends ActivationRequest {
 
     @JsonProperty("content")
     private HashMap content;

--- a/src/main/java/io/chino/api/group/CreateGroupRequest.java
+++ b/src/main/java/io/chino/api/group/CreateGroupRequest.java
@@ -3,12 +3,13 @@ package io.chino.api.group;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.chino.api.common.ActivationRequest;
 
 import java.util.HashMap;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "group_name", "attributes" })
-public class CreateGroupRequest {
+public class CreateGroupRequest extends ActivationRequest {
 
 	@JsonProperty("group_name")
 	private String groupName;

--- a/src/main/java/io/chino/api/schema/SchemaRequest.java
+++ b/src/main/java/io/chino/api/schema/SchemaRequest.java
@@ -3,6 +3,7 @@ package io.chino.api.schema;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.chino.api.common.ActivationRequest;
 import io.chino.api.common.Field;
 
 /**
@@ -14,7 +15,7 @@ import io.chino.api.common.Field;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "description", "structure" })
-public class SchemaRequest {
+public class SchemaRequest extends ActivationRequest {
 
 	@JsonProperty("description")
 	private String description;

--- a/src/main/java/io/chino/api/search/SearchCondition.java
+++ b/src/main/java/io/chino/api/search/SearchCondition.java
@@ -3,7 +3,6 @@ package io.chino.api.search;
 import io.chino.api.common.UnmodifiableList;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.ListIterator;
 

--- a/src/main/java/io/chino/api/user/CreateUserRequest.java
+++ b/src/main/java/io/chino/api/user/CreateUserRequest.java
@@ -4,6 +4,7 @@ package io.chino.api.user;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.chino.api.common.ActivationRequest;
 
 import java.util.HashMap;
 
@@ -13,7 +14,7 @@ import java.util.HashMap;
     "password",
     "attributes"
 })
-public class CreateUserRequest {
+public class CreateUserRequest extends ActivationRequest {
 
     @JsonProperty("username")
     private String username;

--- a/src/main/java/io/chino/api/userschema/UserSchemaRequest.java
+++ b/src/main/java/io/chino/api/userschema/UserSchemaRequest.java
@@ -3,6 +3,7 @@ package io.chino.api.userschema;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.chino.api.common.ActivationRequest;
 
 /**
  * Contains all the parameters required for creation and update of {@link UserSchema UserSchemas}:
@@ -13,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({ "description", "structure" })
-public class UserSchemaRequest {
+public class UserSchemaRequest extends ActivationRequest {
 
 	@JsonProperty("description")
 	private String description;

--- a/src/main/java/io/chino/java/Applications.java
+++ b/src/main/java/io/chino/java/Applications.java
@@ -134,15 +134,32 @@ public class Applications extends ChinoBaseAPI {
     }
 
     /**
-     * It deletes the Application
+     * It deletes the Application.<br>
+     * <br>
+     * <b>This method has been deprecated since API version 3.2.1 and might be removed at any time.</b>
+     * It's strongly suggested to use {@link #delete(String)} instead.
+     *
      * @param applicationId the id of the Application
-     * @param force if true, the resource cannot be restored
+     * @param force ignored
      * @return a String with the result of the operation
      * @throws IOException data processing error
      * @throws ChinoApiException server error
      */
+    @Deprecated
     public String delete(String applicationId, boolean force) throws IOException, ChinoApiException {
+        return delete(applicationId);
+    }
+
+    /**
+     * It deletes the Application
+     * @param applicationId the id of the Application
+     * @return a String with the result of the operation
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    public String delete(String applicationId) throws IOException, ChinoApiException {
         checkNotNull(applicationId, "application_id");
-        return deleteResource("/auth/applications/"+applicationId, force);
+        // 'force' parameter is ignored for Applications
+        return deleteResource("/auth/applications/"+applicationId, false);
     }
 }

--- a/src/main/java/io/chino/java/Blobs.java
+++ b/src/main/java/io/chino/java/Blobs.java
@@ -377,7 +377,10 @@ public class Blobs extends ChinoBaseAPI {
     }
 
     /**
-     * Delete a BLOB from Chino.io. This operation can not be undone.
+     * Delete a BLOB from Chino.io. This operation can not be undone.<br>
+     * <br>
+     * <b>This method has been deprecated since API version 3.2.1 and might be removed at any time.</b>
+     * It's strongly suggested to use {@link #delete(String)} instead.
      *
      * @param blobId the id of the BLOB to delete
      * @param force if true, the resource cannot be restored. Otherwise, it will only become inactive.
@@ -388,6 +391,7 @@ public class Blobs extends ChinoBaseAPI {
      * @throws IOException data processing error
      * @throws ChinoApiException server error
      */
+    @Deprecated
     public String delete(String blobId, boolean force) throws IOException, ChinoApiException {
         checkNotNull(blobId, "blob_id");
         return deleteResource("/blobs/"+blobId, force);
@@ -405,6 +409,7 @@ public class Blobs extends ChinoBaseAPI {
      */
     public String delete(String blobId) throws IOException, ChinoApiException {
         checkNotNull(blobId, "blob_id");
+        // 'force' parameter is ignored for BLOBs
         return deleteResource("/blobs/"+blobId, false);
     }
 

--- a/src/main/java/io/chino/java/Blobs.java
+++ b/src/main/java/io/chino/java/Blobs.java
@@ -393,8 +393,7 @@ public class Blobs extends ChinoBaseAPI {
      */
     @Deprecated
     public String delete(String blobId, boolean force) throws IOException, ChinoApiException {
-        checkNotNull(blobId, "blob_id");
-        return deleteResource("/blobs/"+blobId, force);
+        return delete(blobId);
     }
 
     /**

--- a/src/main/java/io/chino/java/ChinoBaseAPI.java
+++ b/src/main/java/io/chino/java/ChinoBaseAPI.java
@@ -3,6 +3,7 @@ package io.chino.java;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.chino.api.common.*;
 import okhttp3.MediaType;
 import okhttp3.Request;
@@ -282,6 +283,20 @@ public class ChinoBaseAPI {
         } else {
             throw new ChinoApiException(mapper.readValue(body, ErrorResponse.class));
         }
+    }
+
+    /**
+     * Modify the JSON body of an API call, adding the property:<br><br>
+     *  {@code "is_active": true}<br><br>
+     * that can be used to re-activate resources on Chino.io.
+     * If the {@link JsonNode} already has a "is_active" field, this method does nothing.
+     *
+     * @param requestBody the {@link JsonNode} that will be sent in the API call
+     */
+    public void activateResource(JsonNode requestBody) {
+        if (requestBody.has("is_active"))
+            return;
+        ((ObjectNode) requestBody).put("is_active", true);
     }
 
     //This function is static because there are some classes in io.chino.api that needs a mapper without instantiating a new ChinoBaseAPI()

--- a/src/main/java/io/chino/java/ChinoBaseAPI.java
+++ b/src/main/java/io/chino/java/ChinoBaseAPI.java
@@ -3,7 +3,6 @@ package io.chino.java;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.chino.api.common.*;
 import okhttp3.MediaType;
 import okhttp3.Request;
@@ -283,20 +282,6 @@ public class ChinoBaseAPI {
         } else {
             throw new ChinoApiException(mapper.readValue(body, ErrorResponse.class));
         }
-    }
-
-    /**
-     * Modify the JSON body of an API call, adding the property:<br><br>
-     *  {@code "is_active": true}<br><br>
-     * that can be used to re-activate resources on Chino.io.
-     * If the {@link JsonNode} already has a "is_active" field, this method does nothing.
-     *
-     * @param requestBody the {@link JsonNode} that will be sent in the API call
-     */
-    public void activateResource(JsonNode requestBody) {
-        if (requestBody.has("is_active"))
-            return;
-        ((ObjectNode) requestBody).put("is_active", true);
     }
 
     //This function is static because there are some classes in io.chino.api that needs a mapper without instantiating a new ChinoBaseAPI()

--- a/src/main/java/io/chino/java/Collections.java
+++ b/src/main/java/io/chino/java/Collections.java
@@ -32,7 +32,7 @@ public class Collections extends ChinoBaseAPI {
      *
      * @param offset the list offset (how many are skipped)
      * @param limit maximum number of results (must be below
-     *              {@link io.chino.api.common.ChinoApiConstants#QUERY_DEFAULT_LIMIT ChinoApiConstants.QUERY_DEFAULT_LIMIT})
+     *          {@link io.chino.api.common.ChinoApiConstants#QUERY_DEFAULT_LIMIT ChinoApiConstants.QUERY_DEFAULT_LIMIT})
      *
      * @return A {@link GetCollectionsResponse} which wraps the {@link java.util.List} of {@link Collection Collections}
      *
@@ -73,7 +73,9 @@ public class Collections extends ChinoBaseAPI {
      */
     public Collection read(String collectionId) throws IOException, ChinoApiException{
         checkNotNull(collectionId, "collection_id");
-        JsonNode data = getResource("/collections/"+collectionId, 0, ChinoApiConstants.QUERY_DEFAULT_LIMIT);
+        JsonNode data = getResource("/collections/" + collectionId, 0,
+                ChinoApiConstants.QUERY_DEFAULT_LIMIT
+        );
         if(data!=null)
             return mapper.convertValue(data, GetCollectionResponse.class).getCollection();
 
@@ -111,20 +113,43 @@ public class Collections extends ChinoBaseAPI {
      * @throws ChinoApiException server error
      */
     public GetCollectionResponse update(String collectionId, String name) throws IOException, ChinoApiException {
+        return update(false, collectionId, name);
+    }
+
+    /**
+     * Update the name of a {@link Collection}.
+     * Use this method with {@code activateResource=true} to make sure that the resource is active whenyou update it.
+     *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     * @param collectionId the id of the {@link Collection} to update
+     * @param name the new name of the {@link Collection}
+     *
+     * @return a {@link GetCollectionResponse} which wraps the updated Collection.
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    public GetCollectionResponse update(boolean activateResource, String collectionId, String name)
+            throws IOException, ChinoApiException
+    {
         checkNotNull(collectionId, "collection_id");
         CreateCollectionRequest collectionRequest = new CreateCollectionRequest(name);
+        if (activateResource)
+            collectionRequest.activateResource();
         JsonNode data = putResource("/collections/"+collectionId, collectionRequest);
         if(data!=null)
             return mapper.convertValue(data, GetCollectionResponse.class);
         return null;
     }
 
+
     /**
      * Get the {@link io.chino.api.document.Document Documents} in a Collection
      *
      * @param collectionId the id of the Collection
      * @param offset the list offset (how many are skipped)
-     * @param limit maximum number of results (must be below {@link io.chino.api.common.ChinoApiConstants#QUERY_DEFAULT_LIMIT ChinoApiConstants.QUERY_DEFAULT_LIMIT})
+     * @param limit maximum number of results (must be below
+     *          {@link io.chino.api.common.ChinoApiConstants#QUERY_DEFAULT_LIMIT ChinoApiConstants.QUERY_DEFAULT_LIMIT})
      *
      * @return a {@link GetDocumentsResponse} which wraps the {@link java.util.List} of
      *          {@link io.chino.api.document.Document Documents}
@@ -132,7 +157,9 @@ public class Collections extends ChinoBaseAPI {
      * @throws IOException data processing error
      * @throws ChinoApiException server error
      */
-    public GetDocumentsResponse listDocuments(String collectionId, int offset, int limit)throws IOException, ChinoApiException {
+    public GetDocumentsResponse listDocuments(String collectionId, int offset, int limit)
+            throws IOException, ChinoApiException
+    {
         checkNotNull(collectionId, "collection_id");
         JsonNode data = getResource("/collections/"+collectionId+"/documents", offset, limit);
         if(data!=null)
@@ -153,7 +180,9 @@ public class Collections extends ChinoBaseAPI {
      */
     public GetDocumentsResponse listDocuments(String collectionId)throws IOException, ChinoApiException {
         checkNotNull(collectionId, "collection_id");
-        JsonNode data = getResource("/collections/"+collectionId+"/documents", 0, ChinoApiConstants.QUERY_DEFAULT_LIMIT);
+        JsonNode data = getResource("/collections/"+collectionId+"/documents", 0,
+                ChinoApiConstants.QUERY_DEFAULT_LIMIT
+        );
         if(data!=null)
             return mapper.convertValue(data, GetDocumentsResponse.class);
         return null;
@@ -212,5 +241,4 @@ public class Collections extends ChinoBaseAPI {
         checkNotNull(collectionId, "collection_id");
         return deleteResource("/collections/"+collectionId, force);
     }
-
 }

--- a/src/main/java/io/chino/java/Collections.java
+++ b/src/main/java/io/chino/java/Collections.java
@@ -191,6 +191,7 @@ public class Collections extends ChinoBaseAPI {
     public String removeDocument(String collectionId, String documentId)throws IOException, ChinoApiException {
         checkNotNull(collectionId, "collection_id");
         checkNotNull(documentId, "document_id");
+        // 'force' parameter is ignored when deleting collections
         deleteResource("/collections/"+collectionId+"/documents/"+documentId, false);
         return SUCCESS_MSG;
     }

--- a/src/main/java/io/chino/java/Collections.java
+++ b/src/main/java/io/chino/java/Collections.java
@@ -117,10 +117,12 @@ public class Collections extends ChinoBaseAPI {
     }
 
     /**
-     * Update the name of a {@link Collection}.
-     * Use this method with {@code activateResource=true} to make sure that the resource is active whenyou update it.
+     * Update the name of a {@link Collection}.<br>
+     * Use this method with {@code activateResource=true} to make sure that the resource is active when you update it.
+     * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
      *
      * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value will not be modified.
      * @param collectionId the id of the {@link Collection} to update
      * @param name the new name of the {@link Collection}
      *

--- a/src/main/java/io/chino/java/Collections.java
+++ b/src/main/java/io/chino/java/Collections.java
@@ -122,7 +122,7 @@ public class Collections extends ChinoBaseAPI {
      * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
      *
      * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
-     *                         Otherwise, the value will not be modified.
+     *                         Otherwise, the value of is_active will not be modified.
      * @param collectionId the id of the {@link Collection} to update
      * @param name the new name of the {@link Collection}
      *

--- a/src/main/java/io/chino/java/Consents.java
+++ b/src/main/java/io/chino/java/Consents.java
@@ -48,18 +48,18 @@ public class Consents extends ChinoBaseAPI {
      */
     public ConsentList list(String userId, int offset, int limit) throws IOException, ChinoApiException {
         HashMap<String, String> params = new HashMap<>();
-        
+
         String userIdValue = (userId == null) ? "" : userId;
-        
+
         String offsetValue = (offset < 0) ? "0" : "" + offset,
                 limitValue = (limit < 0) ? "0" : "" + limit;
-        
+
         params.put("userId", userIdValue);
         params.put("offset", offsetValue);
         params.put("limit", limitValue);
-        
+
         JsonNode data = getResource("/consents", params);
-        
+
         if (data != null) {
             ConsentListWrapper wrapper = mapper.convertValue(data, ConsentListWrapper.class);
             return new ConsentList(wrapper);
@@ -67,7 +67,7 @@ public class Consents extends ChinoBaseAPI {
             return null;
         }
     }
-    
+
     /**
      * List all the available {@link Consent consents}. The results are paginated.
      * @param offset page offset of the results.
@@ -100,7 +100,7 @@ public class Consents extends ChinoBaseAPI {
     public ConsentList list() throws IOException, ChinoApiException {
         return list(null, 0, ChinoApiConstants.QUERY_DEFAULT_LIMIT);
     }
-    
+
     /**
      * Create a new {@link Consent} on Chino.io, passing a local {@link Consent}
      * object.
@@ -116,7 +116,7 @@ public class Consents extends ChinoBaseAPI {
         else
             return null;
     }
-    
+
     /**
      * Create a new {@link Consent} on Chino.io with the specified data and
      * maps the API response to a new {@link Consent} object.<br>
@@ -124,9 +124,9 @@ public class Consents extends ChinoBaseAPI {
      * Check
      * <a href="https://docs.chino.io//#consent-management">Chino.io API documentation</a>
      * to learn more about the parameters of the Consent Object.
-     * 
+     *
      * @see Consent#Consent(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, io.chino.api.consent.DataController, java.util.List) Consent() full constructor
-     * 
+     *
      * @param userId
      * @param description
      * @param policyUrl
@@ -151,13 +151,13 @@ public class Consents extends ChinoBaseAPI {
         checkNotNull(collectionMode, "collection_mode");
         checkNotNull(dataController, "data_controller");
         checkNotNull(purposes, "purposes");
-        
+
         return create(
                 new Consent(userId, description, policyUrl, policyVersion, collectionMode, dataController, purposes)
         );
-        
+
     }
-    
+
     /**
      * Create a new {@link Consent} on Chino.io with the specified data and
      * maps the API response to a new {@link Consent} object.<br>
@@ -165,9 +165,9 @@ public class Consents extends ChinoBaseAPI {
      * Check
      * <a href="https://docs.chino.io//#consent-management">Chino.io API documentation</a>
      * to learn more about the parameters of the Consent Object.
-     * 
+     *
      * @see Consent#Consent(io.chino.api.consent.Consent, io.chino.api.consent.DataController, java.util.List) Consent constructor by data_controller/purposes
-     * 
+     *
      * @param base the base {@link Consent} object
      * @param newDataController the new {@link DataController};
      * if {@code null}, the value will be copied from {@code base}.
@@ -187,7 +187,7 @@ public class Consents extends ChinoBaseAPI {
                 new Consent(base, newDataController, newPurposes)
         );
     }
-    
+
     /**
      * Create a new {@link Consent} on Chino.io with the specified data and
      * maps the API response to a new {@link Consent} object.<br>
@@ -195,9 +195,9 @@ public class Consents extends ChinoBaseAPI {
      * Check
      * <a href="https://docs.chino.io//#consent-management">Chino.io API documentation</a>
      * to learn more about the parameters of the Consent Object.
-     * 
+     *
      * @see Consent#Consent(io.chino.api.consent.Consent, java.lang.String)  Consent  constructor by user_id
-     * 
+     *
      * @param base the base {@link Consent} object
      * @param userId the new {@link User#getUserId()}  userId}. <b>Cannot be {@code null}</b>
      * @return the {@link Consent} object that was just created on Chino.io.
@@ -213,7 +213,7 @@ public class Consents extends ChinoBaseAPI {
                 new Consent(base, userId)
         );
     }
-    
+
     /**
      * Fetch the consent with the specified {@code consent_id}.
      * If there is a history for this {@link Consent} object, only the active
@@ -234,13 +234,13 @@ public class Consents extends ChinoBaseAPI {
             return null;
         }
     }
-    
+
     /**
      * Updates the {@link Consent} with matching {@code consentId};
      * the old version is kept in the Consent's history for future reference
      * and its {@link Consent#withdrawnDate withdrawn_date} field is set to a
      * non-null value.
-     * 
+     *
      * @see #history(java.lang.String) history()
      * @param consentId the consent_id of the {@link Consent} to update
      * @param consentData an instance of {@link Consent} containing the updated values
@@ -260,8 +260,8 @@ public class Consents extends ChinoBaseAPI {
         else
             return null;
     }
-    
-    
+
+
     /**
      * Fetch the history of the {@link Consent} with the specified {@code consentId}.
      * @param consentId the id of the consents in the consent history
@@ -275,23 +275,26 @@ public class Consents extends ChinoBaseAPI {
     public ConsentHistory history(String consentId) throws IOException, ChinoApiException {
         checkNotNull(consentId, "consent_id");
         JsonNode rawData = getResource("/consents/" + consentId + "/history");
-        
+
         if (rawData != null) {
-            ConsentListWrapper wrapper = mapper.convertValue(rawData, ConsentListWrapper.class);            
+            ConsentListWrapper wrapper = mapper.convertValue(rawData, ConsentListWrapper.class);
             return new ConsentHistory(wrapper);
         } else {
             return null;
         }
     }
-    
+
     /**
      * Withdraw the {@link Consent} with the specified {@code consentId}.
      * The consent's {@link Consent#withdrawnDate withdrawn_date} will be set
-     * to a non-null value and the object will no longer be active. 
+     * to a non-null value and the object will no longer be active.
      * Inactive Consents cannot be updated, but their history is available
      * on the server as a proof.
+     *
      * @param consentId id of the {@link Consent} to be withdrawn
+     *
      * @return the result {@link String}, as returned by the server.
+     *
      * @throws java.io.IOException request could not be executed
      * (but it might have arrived to the server).
      * @throws io.chino.api.common.ChinoApiException Chino.io
@@ -301,14 +304,17 @@ public class Consents extends ChinoBaseAPI {
         checkNotNull(consentId, "consent_id");
         return deleteResource("/consents/" + consentId, false);
     }
-    
+
     /**
      * Deletes the {@link Consent} with the specified {@code consentId} from
      * Chino.io servers. Consents are no more available after deletion.
      * <b>This feature only works with the test API at
      * <code>api.test.chino.io</code> and is not available in production.</b>
+     *
      * @param consentId id of the {@link Consent} to be deleted
+     *
      * @return the result {@link String}, as returned by the server.
+     *
      * @throws java.io.IOException request could not be executed
      * (but it might have arrived to the server).
      * @throws io.chino.api.common.ChinoApiException Chino.io
@@ -316,7 +322,8 @@ public class Consents extends ChinoBaseAPI {
      */
     public String delete(String consentId) throws IOException, ChinoApiException {
         checkNotNull(consentId, "consent_id");
-        // 'force' parameter is ignored for Consents
-        return deleteResource("/consents/" + consentId, false);
+        // 'force' parameter must be set to true to delete Consents.
+        // to send a request with force=false, please use method withdraw()
+        return deleteResource("/consents/" + consentId, true);
     }
 }

--- a/src/main/java/io/chino/java/Consents.java
+++ b/src/main/java/io/chino/java/Consents.java
@@ -316,6 +316,7 @@ public class Consents extends ChinoBaseAPI {
      */
     public String delete(String consentId) throws IOException, ChinoApiException {
         checkNotNull(consentId, "consent_id");
-        return deleteResource("/consents/" + consentId, true);
+        // 'force' parameter is ignored for Consents
+        return deleteResource("/consents/" + consentId, false);
     }
 }

--- a/src/main/java/io/chino/java/Documents.java
+++ b/src/main/java/io/chino/java/Documents.java
@@ -284,8 +284,36 @@ public class Documents extends ChinoBaseAPI {
      * @throws ChinoApiException server error
      */
     public Document update(String documentId, HashMap content, boolean consistent) throws IOException, ChinoApiException {
+        return update(false, documentId, content, consistent);
+    }
+
+    /**
+     * Update a specific {@link Document} on Chino.io with new data (synchronous)<br>
+     * Use this method with {@code activateResource=true} to make sure that the resource is active when you update it.
+     * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
+     *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value will not be modified.
+     * @param documentId the id of an existing {@link Document}. IDs can be retrieved using one of the 'list' methods,
+     *                   e.g. {@link #list(String) list(schemaId)}
+     * @param content a {@link HashMap} with the content of the new Document.
+     *                The map's keys must match the fields of the Schema.
+     * @param consistent setting this flag to {@code true} will make the indexing synchronous with the update,
+     *                   i.e. search operations will be successful right after this method returns.
+     *                   However, this operation has a cost and can make the API call last for seconds before answering.
+     *                   Use only when it's really needed
+     *
+     * @return the metadata of the updated Document. <b>NOTE: the Document's content will NOT be returned.</b>
+     *         It can be set with {@link Document#setContent(HashMap)} or fetched from Chino.io with {@link #read(String) read(documentId)}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    public Document update(boolean activateResource, String documentId, HashMap content, boolean consistent) throws IOException, ChinoApiException {
         checkNotNull(documentId, "document_id");
         CreateDocumentRequest createDocumentRequest = new CreateDocumentRequest(content);
+        if(activateResource)
+            createDocumentRequest.activateResource();
         String URL = "/documents/" + documentId + ((consistent) ? "?consistent=true" : "");
         JsonNode data = putResource(URL, createDocumentRequest);
         if(data!=null)
@@ -313,6 +341,28 @@ public class Documents extends ChinoBaseAPI {
     }
 
     /**
+     * Update a specific {@link Document} on Chino.io with new data.<br>
+     * Use this method with {@code activateResource=true} to make sure that the resource is active when you update it.
+     * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
+     *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value will not be modified.
+     * @param documentId the id of an existing {@link Document}. IDs can be retrieved using one of the 'list' methods,
+     *                   e.g. {@link #list(String) list(schemaId)}
+     * @param content a {@link HashMap} with the content of the new Document.
+     *                The map's keys must match the fields of the Schema.
+     *
+     * @return the metadata of the updated Document. <b>NOTE: the Document's content will NOT be returned.</b>
+     *         It can be set with {@link Document#setContent(HashMap)} or fetched from Chino.io with {@link #read(String) read(documentId)}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    public Document update(boolean activateResource, String documentId, HashMap content) throws IOException, ChinoApiException {
+        return update(activateResource, documentId, content, false);
+    }
+
+    /**
      * Update a specific {@link Document} on Chino.io with new data (synchronous)
      *
      * @param documentId the id of an existing {@link Document}. IDs can be retrieved using one of the 'list' methods,
@@ -331,8 +381,36 @@ public class Documents extends ChinoBaseAPI {
      * @throws ChinoApiException server error
      */
     public Document update(String documentId, String content, boolean consistent) throws IOException, ChinoApiException {
+        return update(false, documentId, content, consistent);
+    }
+
+    /**
+     * Update a specific {@link Document} on Chino.io with new data (synchronous)<br>
+     * Use this method with {@code activateResource=true} to make sure that the resource is active when you update it.
+     * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
+     *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value will not be modified.
+     * @param documentId the id of an existing {@link Document}. IDs can be retrieved using one of the 'list' methods,
+     *                   e.g. {@link #list(String) list(schemaId)}
+     * @param content a {@link String} with the content of the new Document in JSON format.
+     *                The structure of the JSON must match the one of the Schema.
+     * @param consistent setting this flag to {@code true} will make the indexing synchronous with the update,
+     *                   i.e. search operations will be successful right after this method returns.
+     *                   However, this operation has a cost and can make the API call last for seconds before answering.
+     *                   Use only when it's really needed
+     *
+     * @return the metadata of the updated Document. <b>NOTE: the Document's content will NOT be returned.</b>
+     *         It can be set with {@link Document#setContent(HashMap)} or fetched from Chino.io with {@link #read(String) read(documentId)}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    public Document update(boolean activateResource, String documentId, String content, boolean consistent) throws IOException, ChinoApiException {
         checkNotNull(documentId, "document_id");
         CreateDocumentRequest createDocumentRequest = new CreateDocumentRequest(fromStringToHashMap(content));
+        if(activateResource)
+            createDocumentRequest.activateResource();
         String URL = "/documents/" + documentId + ((consistent) ? "?consistent=true" : "");
         JsonNode data = putResource(URL, createDocumentRequest);
         if(data!=null)
@@ -357,7 +435,30 @@ public class Documents extends ChinoBaseAPI {
      */
 
     public Document update(String documentId, String content) throws IOException, ChinoApiException {
-        return update(documentId, content, false);
+        return update(false, documentId, content, false);
+    }
+
+    /**
+     * Update a specific {@link Document} on Chino.io with new data.<br>
+     * Use this method with {@code activateResource=true} to make sure that the resource is active when you update it.
+     * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
+     *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value will not be modified.
+     * @param documentId the id of an existing {@link Document}. IDs can be retrieved using one of the 'list' methods,
+     *                   e.g. {@link #list(String) list(schemaId)}
+     * @param content a {@link String} with the content of the new Document in JSON format.
+     *                The structure of the JSON must match the one of the Schema.
+     *
+     * @return the metadata of the updated Document. <b>NOTE: the Document's content will NOT be returned.</b>
+     *         It can be set with {@link Document#setContent(HashMap)} or fetched from Chino.io with {@link #read(String) read(documentId)}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+
+    public Document update(boolean activateResource, String documentId, String content) throws IOException, ChinoApiException {
+        return update(activateResource, documentId, content, false);
     }
 
     /**

--- a/src/main/java/io/chino/java/Documents.java
+++ b/src/main/java/io/chino/java/Documents.java
@@ -293,7 +293,7 @@ public class Documents extends ChinoBaseAPI {
      * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
      *
      * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
-     *                         Otherwise, the value will not be modified.
+     *                         Otherwise, the value of is_active will not be modified.
      * @param documentId the id of an existing {@link Document}. IDs can be retrieved using one of the 'list' methods,
      *                   e.g. {@link #list(String) list(schemaId)}
      * @param content a {@link HashMap} with the content of the new Document.
@@ -346,7 +346,7 @@ public class Documents extends ChinoBaseAPI {
      * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
      *
      * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
-     *                         Otherwise, the value will not be modified.
+     *                         Otherwise, the value of is_active will not be modified.
      * @param documentId the id of an existing {@link Document}. IDs can be retrieved using one of the 'list' methods,
      *                   e.g. {@link #list(String) list(schemaId)}
      * @param content a {@link HashMap} with the content of the new Document.
@@ -390,7 +390,7 @@ public class Documents extends ChinoBaseAPI {
      * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
      *
      * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
-     *                         Otherwise, the value will not be modified.
+     *                         Otherwise, the value of is_active will not be modified.
      * @param documentId the id of an existing {@link Document}. IDs can be retrieved using one of the 'list' methods,
      *                   e.g. {@link #list(String) list(schemaId)}
      * @param content a {@link String} with the content of the new Document in JSON format.
@@ -444,7 +444,7 @@ public class Documents extends ChinoBaseAPI {
      * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
      *
      * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
-     *                         Otherwise, the value will not be modified.
+     *                         Otherwise, the value of is_active will not be modified.
      * @param documentId the id of an existing {@link Document}. IDs can be retrieved using one of the 'list' methods,
      *                   e.g. {@link #list(String) list(schemaId)}
      * @param content a {@link String} with the content of the new Document in JSON format.

--- a/src/main/java/io/chino/java/Groups.java
+++ b/src/main/java/io/chino/java/Groups.java
@@ -117,9 +117,30 @@ public class Groups extends ChinoBaseAPI {
      * @throws ChinoApiException server error
      */
     public Group update(String groupId, String groupName, HashMap attributes) throws IOException, ChinoApiException {
+        return update(false, groupId, groupName, attributes);
+    }
+
+    /**
+     * Update an existing {@link Group}<br>
+     * Use this method with {@code activateResource=true} to make sure that the resource is active when you update it.
+     * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
+     *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value will not be modified.
+     * @param groupId the id of the Group
+     * @param groupName the name of the new Group
+     * @param attributes an HashMap of the new attributes
+     *
+     * @return the updated {@link Group}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    public Group update(boolean activateResource, String groupId, String groupName, HashMap attributes) throws IOException, ChinoApiException {
         checkNotNull(groupId, "group_id");
         CreateGroupRequest createGroupRequest=new CreateGroupRequest(groupName, attributes);
-
+        if (activateResource)
+            createGroupRequest.activateResource();
         JsonNode data = putResource("/groups/"+groupId, createGroupRequest);
         if(data!=null)
             return mapper.convertValue(data, GetGroupResponse.class).getGroup();

--- a/src/main/java/io/chino/java/Groups.java
+++ b/src/main/java/io/chino/java/Groups.java
@@ -126,7 +126,7 @@ public class Groups extends ChinoBaseAPI {
      * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
      *
      * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
-     *                         Otherwise, the value will not be modified.
+     *                         Otherwise, the value of is_active will not be modified.
      * @param groupId the id of the Group
      * @param groupName the name of the new Group
      * @param attributes an HashMap of the new attributes

--- a/src/main/java/io/chino/java/Repositories.java
+++ b/src/main/java/io/chino/java/Repositories.java
@@ -122,7 +122,7 @@ public class Repositories extends ChinoBaseAPI {
      * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
      *
      * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
-     *                         Otherwise, the value will not be modified.
+     *                         Otherwise, the value of is_active will not be modified.
      * @param repositoryId the id of the {@link Repository} on Chino.io
      * @param description the new description of the Repository
      *

--- a/src/main/java/io/chino/java/Repositories.java
+++ b/src/main/java/io/chino/java/Repositories.java
@@ -113,9 +113,32 @@ public class Repositories extends ChinoBaseAPI {
      * @throws ChinoApiException server error
      */
     public Repository update(String repositoryId, String description) throws IOException, ChinoApiException {
+        return update(false, repositoryId, description);
+    }
+
+    /**
+     * Update an existing {@link Repository}<br>
+     * Use this method with {@code activateResource=true} to make sure that the resource is active when you update it.
+     * NOTE: this method can NOT be used to set the resource inactive: use {@link #delete(String, boolean)} instead.
+     *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value will not be modified.
+     * @param repositoryId the id of the {@link Repository} on Chino.io
+     * @param description the new description of the Repository
+     *
+     * @return the updated {@link Repository}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    public Repository update(boolean activateResource, String repositoryId, String description) throws IOException, ChinoApiException {
         checkNotNull(repositoryId, "repository_id");
         checkNotNull(description, "description");
-        String createRepoRequest="{\"description\": \""+description+"\"}";
+        String descriptionField = String.format("\"description\": \"%s\"", description);
+        String isActiveField = activateResource
+                ? ",\n\"is_active\": true"
+                : "";
+        String createRepoRequest= "{\n" + descriptionField + isActiveField +"\n}";
         JsonNode createRepoRequestNode= mapper.readValue(createRepoRequest, JsonNode.class);
 
         JsonNode data = putResource("/repositories/"+repositoryId, createRepoRequestNode);

--- a/src/main/java/io/chino/java/Schemas.java
+++ b/src/main/java/io/chino/java/Schemas.java
@@ -154,23 +154,16 @@ public class Schemas extends ChinoBaseAPI {
      * Update an existing {@link Schema}
      *
      * @param schemaId the ID of the Schema to update
-     * @param description the new description of the Schema
-     * @param schemaStructure a {@link SchemaStructure} object that contains the new structure of the Schema
+     * @param schemaRequest a {@link SchemaStructure} object that contains the new description
+     *                      and structure of the Schema
      *
      * @return the updated {@link Schema}
      *
      * @throws IOException data processing error
      * @throws ChinoApiException server error
      */
-    public Schema update(String schemaId, String description, SchemaStructure schemaStructure) throws IOException, ChinoApiException {
-        checkNotNull(schemaId, "schema_id");
-        SchemaRequest schemaRequest = new SchemaRequest(description, schemaStructure);
-
-        JsonNode data = putResource("/schemas/"+schemaId, schemaRequest);
-        if(data!=null)
-            return mapper.convertValue(data, GetSchemaResponse.class).getSchema();
-
-        return null;
+    public Schema update(String schemaId, SchemaRequest schemaRequest) throws IOException, ChinoApiException {
+        return update(false, schemaId, schemaRequest);
     }
 
     /**
@@ -185,13 +178,52 @@ public class Schemas extends ChinoBaseAPI {
      * @throws IOException data processing error
      * @throws ChinoApiException server error
      */
-    public Schema update(String schemaId, SchemaRequest schemaRequest) throws IOException, ChinoApiException {
+    public Schema update(boolean activateResource, String schemaId, SchemaRequest schemaRequest) throws IOException, ChinoApiException {
         checkNotNull(schemaId, "schema_id");
-        JsonNode data = putResource("/schemas/"+schemaId, schemaRequest);
-        if(data!=null)
+        if (activateResource) {
+            schemaRequest.activateResource();
+        }
+        JsonNode data = putResource("/schemas/" + schemaId, schemaRequest);
+        if (data != null)
             return mapper.convertValue(data, GetSchemaResponse.class).getSchema();
 
         return null;
+    }
+
+    /**
+     * Update an existing {@link Schema}
+     *
+     * @param schemaId the ID of the Schema to update
+     * @param description the new description of the Schema
+     * @param schemaStructure a {@link SchemaStructure} object that contains the new structure of the Schema
+     *
+     * @return the updated {@link Schema}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    public Schema update(String schemaId, String description, SchemaStructure schemaStructure) throws IOException, ChinoApiException {
+        checkNotNull(schemaId, "schema_id");
+        SchemaRequest schemaRequest = new SchemaRequest(description, schemaStructure);
+        return update(false, schemaId, schemaRequest);
+    }
+
+    /**
+     * Update an existing {@link Schema}
+     *
+     * @param schemaId the ID of the Schema to update
+     * @param description the new description of the Schema
+     * @param schemaStructure a {@link SchemaStructure} object that contains the new structure of the Schema
+     *
+     * @return the updated {@link Schema}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    public Schema update(boolean activateResource, String schemaId, String description, SchemaStructure schemaStructure) throws IOException, ChinoApiException {
+        checkNotNull(schemaId, "schema_id");
+        SchemaRequest schemaRequest = new SchemaRequest(description, schemaStructure);
+        return update(activateResource, schemaId, schemaRequest);
     }
 
     /**
@@ -209,6 +241,24 @@ public class Schemas extends ChinoBaseAPI {
      * @see io.chino.api.common.indexed @indexed
      */
     public Schema update(String schemaId, String description, Class myClass) throws IOException, ChinoApiException {
+        return update(false, schemaId, description, myClass);
+    }
+
+    /**
+     * Update an existing {@link Schema}
+     *
+     * @param schemaId the ID of the Schema to update
+     * @param description the new description of the Schema
+     * @param myClass {@link Class} that represents the new structure of the {@link Schema}
+     *
+     * @return the updated {@link Schema}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     *
+     * @see io.chino.api.common.indexed @indexed
+     */
+    public Schema update(boolean activateResource, String schemaId, String description, Class myClass) throws IOException, ChinoApiException {
         checkNotNull(schemaId, "schema_id");
         SchemaRequest schemaRequest = new SchemaRequest();
         schemaRequest.setDescription(description);
@@ -217,11 +267,7 @@ public class Schemas extends ChinoBaseAPI {
         schemaStructure.setFields(fieldsList);
         schemaRequest.setStructure(schemaStructure);
 
-        JsonNode data = putResource("/schemas/"+schemaId, schemaRequest);
-        if(data!=null)
-            return mapper.convertValue(data, GetSchemaResponse.class).getSchema();
-
-        return null;
+        return update(activateResource, schemaId, schemaRequest);
     }
 
     /**

--- a/src/main/java/io/chino/java/UserSchemas.java
+++ b/src/main/java/io/chino/java/UserSchemas.java
@@ -147,21 +147,22 @@ public class UserSchemas extends ChinoBaseAPI {
     /**
      * Update the specified {@link UserSchema}
      *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value of is_active will not be modified.
      * @param userSchemaId the id of the {@link UserSchema} on Chino.io
-     * @param description the new description for the UserSchema
-     * @param userSchemaStructure a {@link UserSchemaStructure} object which describes the new structure
-     *                            of the UserSchema.
+     * @param userSchemaRequest a {@link UserSchemaRequest} Object which contains the new description and the
+     *                          new structure of the UserSchema's fields
      *
      * @return the updated {@link UserSchema}
      *
      * @throws IOException data processing error
      * @throws ChinoApiException server error
      */
-    public UserSchema update(String userSchemaId, String description, UserSchemaStructure userSchemaStructure) throws IOException, ChinoApiException {
+    public UserSchema update(boolean activateResource, String userSchemaId, UserSchemaRequest userSchemaRequest) throws IOException, ChinoApiException {
         checkNotNull(userSchemaId, "user_schema_id");
-        checkNotNull(userSchemaStructure, "user_schema_structure");
-        UserSchemaRequest userSchemaRequest= new UserSchemaRequest(description, userSchemaStructure);
-
+        checkNotNull(userSchemaRequest, "user_schema_request");
+        if (activateResource)
+            userSchemaRequest.activateResource();
         JsonNode data = putResource("/user_schemas/"+userSchemaId, userSchemaRequest);
         if(data!=null)
             return getMapper().convertValue(data, GetUserSchemaResponse.class).getUserSchema();
@@ -180,13 +181,47 @@ public class UserSchemas extends ChinoBaseAPI {
      * @throws IOException data processing error
      * @throws ChinoApiException server error
      */
-     public UserSchema update(String userSchemaId, UserSchemaRequest userSchemaRequest) throws IOException, ChinoApiException {
-         checkNotNull(userSchemaId, "user_schema_id");
-         checkNotNull(userSchemaRequest, "user_schema_request");
-         JsonNode data = putResource("/user_schemas/"+userSchemaId, userSchemaRequest);
-         if(data!=null)
-             return getMapper().convertValue(data, GetUserSchemaResponse.class).getUserSchema();
-         return null;
+    public UserSchema update(String userSchemaId, UserSchemaRequest userSchemaRequest) throws IOException, ChinoApiException {
+        return update(false, userSchemaId, userSchemaRequest);
+    }
+
+    /**
+     * Update the specified {@link UserSchema}
+     *
+     * @param userSchemaId the id of the {@link UserSchema} on Chino.io
+     * @param description the new description for the UserSchema
+     * @param userSchemaStructure a {@link UserSchemaStructure} object which describes the new structure
+     *                            of the UserSchema.
+     *
+     * @return the updated {@link UserSchema}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    public UserSchema update(String userSchemaId, String description, UserSchemaStructure userSchemaStructure) throws IOException, ChinoApiException {
+        return update(false, userSchemaId, new UserSchemaRequest(description, userSchemaStructure));
+    }
+
+    /**
+     * Update the specified {@link UserSchema}
+     *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value of is_active will not be modified.
+     * @param userSchemaId the id of the {@link UserSchema} on Chino.io
+     * @param description the new description for the UserSchema
+     * @param userSchemaStructure a {@link UserSchemaStructure} object which describes the new structure
+     *                            of the UserSchema.
+     *
+     * @return the updated {@link UserSchema}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    public UserSchema update(boolean activateResource, String userSchemaId, String description, UserSchemaStructure userSchemaStructure) throws IOException, ChinoApiException {
+        checkNotNull(userSchemaId, "user_schema_id");
+        checkNotNull(userSchemaStructure, "user_schema_structure");
+
+        return update(activateResource, userSchemaId, new UserSchemaRequest(description, userSchemaStructure));
     }
 
     /**
@@ -204,15 +239,32 @@ public class UserSchemas extends ChinoBaseAPI {
      * @throws ChinoApiException server error
      */
     public UserSchema update(String userSchemaId, String description, Class myClass) throws IOException, ChinoApiException {
+        return update(false, userSchemaId, description, myClass);
+    }
+
+    /**
+     * Update the specified {@link UserSchema}
+     *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value of is_active will not be modified.
+     * @param userSchemaId the id of the {@link UserSchema} on Chino.io
+     * @param description the new description of the {@link UserSchema}
+     * @param myClass a Java {@link Class} that represents the new structure of the UserSchema.
+     *                Mark fields that need to be indexed with the annotation
+     *                {@link io.chino.api.common.indexed @indexed}.
+     *
+     * @return the updated {@link UserSchema}
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    public UserSchema update(boolean activateResource, String userSchemaId, String description, Class myClass) throws IOException, ChinoApiException {
         checkNotNull(userSchemaId, "user_schema_id");
         List<Field> fieldsList = returnFields(myClass);
         UserSchemaStructure userSchemaStructure = new UserSchemaStructure(fieldsList);
         UserSchemaRequest userSchemaRequest= new UserSchemaRequest(description, userSchemaStructure);
 
-        JsonNode data = putResource("/user_schemas/"+userSchemaId, userSchemaRequest);
-        if(data!=null)
-            return getMapper().convertValue(data, GetUserSchemaResponse.class).getUserSchema();
-        return null;
+        return update(activateResource, userSchemaId, userSchemaRequest);
     }
 
     /**

--- a/src/main/java/io/chino/java/Users.java
+++ b/src/main/java/io/chino/java/Users.java
@@ -335,10 +335,8 @@ public class Users extends ChinoBaseAPI {
             createUserRequest.setPassword((String) attributes.remove("password"));
         }
         createUserRequest.setAttributes(attributes);
-
         if (activateResource)
             createUserRequest.activateResource();
-
         String URL = "/users/" + userId + ((consistent) ? "?consistent=true" : "");
         JsonNode data = patchResource(URL, createUserRequest);
         if(data!=null)

--- a/src/main/java/io/chino/java/Users.java
+++ b/src/main/java/io/chino/java/Users.java
@@ -265,12 +265,14 @@ public class Users extends ChinoBaseAPI {
      */
     @Nullable
     public User updatePartial(String userId, HashMap attributes) throws IOException, ChinoApiException {
-        return updatePartial(userId, attributes, false);
+        return updatePartial(false, userId, attributes, false);
     }
 
     /**
      * Update some fields of a User.
      *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value of is_active will not be modified.
      * @param userId the User's ID on Chino.io
      * @param attributes a {@link HashMap} with the new values of the User's attributes
      *
@@ -280,7 +282,49 @@ public class Users extends ChinoBaseAPI {
      * @throws ChinoApiException server error
      */
     @Nullable
+    public User updatePartial(boolean activateResource, String userId, HashMap attributes) throws IOException, ChinoApiException {
+        return updatePartial(activateResource, userId, attributes, false);
+    }
+
+    /**
+     * Update some fields of a User.
+     *
+     * @param userId the User's ID on Chino.io
+     * @param attributes a {@link HashMap} with the new values of the User's attributes
+     * @param consistent setting this flag to {@code true} will make the indexing synchronous with the creation of the user,
+     *                   i.e. search operations will be successful right after this method returns.
+     *                   However, this operation has a cost and can make the API call last for seconds before answering.
+     *                   Use only when it's really needed
+     *
+     * @return the updated {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    @Nullable
     public User updatePartial(String userId, HashMap attributes, boolean consistent) throws IOException, ChinoApiException {
+        return updatePartial(false, userId, attributes, consistent);
+    }
+
+    /**
+     * Update some fields of a User.
+     *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value of is_active will not be modified.
+     * @param userId the User's ID on Chino.io
+     * @param attributes a {@link HashMap} with the new values of the User's attributes
+     * @param consistent setting this flag to {@code true} will make the indexing synchronous with the creation of the user,
+     *                   i.e. search operations will be successful right after this method returns.
+     *                   However, this operation has a cost and can make the API call last for seconds before answering.
+     *                   Use only when it's really needed
+     *
+     * @return the updated {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    @Nullable
+    public User updatePartial(boolean activateResource, String userId, HashMap attributes, boolean consistent) throws IOException, ChinoApiException {
         checkNotNull(userId, "user_id");
 
         CreateUserRequest createUserRequest= new CreateUserRequest();
@@ -291,6 +335,9 @@ public class Users extends ChinoBaseAPI {
             createUserRequest.setPassword((String) attributes.remove("password"));
         }
         createUserRequest.setAttributes(attributes);
+
+        if (activateResource)
+            createUserRequest.activateResource();
 
         String URL = "/users/" + userId + ((consistent) ? "?consistent=true" : "");
         JsonNode data = patchResource(URL, createUserRequest);
@@ -313,7 +360,26 @@ public class Users extends ChinoBaseAPI {
      */
     @Nullable
     public User updatePartial(String userId, String attributes) throws IOException, ChinoApiException {
-        return updatePartial(userId, attributes, false);
+        return updatePartial(false, userId, attributes, false);
+    }
+
+
+    /**
+     * Update some fields of a User.
+     *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value of is_active will not be modified.
+     * @param userId the User's ID on Chino.io
+     * @param attributes a JSON object (as a {@link String}) with the new values of the User's attributes
+     *
+     * @return the updated {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    @Nullable
+    public User updatePartial(boolean activateResource, String userId, String attributes) throws IOException, ChinoApiException {
+        return updatePartial(activateResource, userId, attributes, false);
     }
 
     /**
@@ -321,6 +387,11 @@ public class Users extends ChinoBaseAPI {
      *
      * @param userId the User's ID on Chino.io
      * @param attributes a JSON object (as a {@link String}) with the new values of the User's attributes
+     * @param consistent setting this flag to {@code true} will make the indexing synchronous with the creation of the user,
+     *                   i.e. search operations will be successful right after this method returns.
+     *                   However, this operation has a cost and can make the API call last for seconds before answering.
+     *                   Use only when it's really needed
+     *
      *
      * @return the updated {@link User} object
      *
@@ -332,9 +403,34 @@ public class Users extends ChinoBaseAPI {
         checkNotNull(userId, "user_id");
         HashMap attrMap =  fromStringToHashMap(attributes);
 
-        return updatePartial(userId, attrMap, consistent);
+        return updatePartial(false, userId, attrMap, consistent);
     }
 
+    /**
+     * Update some fields of a User.
+     *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value of is_active will not be modified.
+     * @param userId the User's ID on Chino.io
+     * @param attributes a JSON object (as a {@link String}) with the new values of the User's attributes
+     * @param consistent setting this flag to {@code true} will make the indexing synchronous with the creation of the user,
+     *                   i.e. search operations will be successful right after this method returns.
+     *                   However, this operation has a cost and can make the API call last for seconds before answering.
+     *                   Use only when it's really needed
+     *
+     *
+     * @return the updated {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    @Nullable
+    public User updatePartial(boolean activateResource, String userId, String attributes, boolean consistent) throws IOException, ChinoApiException {
+        checkNotNull(userId, "user_id");
+        HashMap attrMap =  fromStringToHashMap(attributes);
+
+        return updatePartial(activateResource, userId, attrMap, consistent);
+    }
 
     /**
      * Update a {@link User} object.
@@ -352,13 +448,14 @@ public class Users extends ChinoBaseAPI {
      */
     @Nullable
     public User update(String userId, String username, String password, HashMap attributes) throws IOException, ChinoApiException {
-        return update(userId, username, password, attributes, false);
+        return update(false, userId, username, password, attributes, false);
     }
-
 
     /**
      * Update a {@link User} object.
      *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value of is_active will not be modified.
      * @param userId the User's ID on Chino.io
      * @param username the username of the User
      * @param password the password of the User
@@ -371,9 +468,62 @@ public class Users extends ChinoBaseAPI {
      * @throws ChinoApiException server error
      */
     @Nullable
+    public User update(boolean activateResource, String userId, String username, String password, HashMap attributes) throws IOException, ChinoApiException {
+        return update(activateResource, userId, username, password, attributes, false);
+    }
+
+    /**
+     * Update a {@link User} object.
+     *
+     * @param userId the User's ID on Chino.io
+     * @param username the username of the User
+     * @param password the password of the User
+     * @param attributes an HashMap with the new values of the User's attributes.
+     *                   You must provide <b><i> all </i></b> of the attributes that are defined for the User.
+     * @param consistent setting this flag to {@code true} will make the indexing synchronous with the creation of the user,
+     *                   i.e. search operations will be successful right after this method returns.
+     *                   However, this operation has a cost and can make the API call last for seconds before answering.
+     *                   Use only when it's really needed
+     *
+     *
+     * @return the updated {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    @Nullable
     public User update(String userId, String username, String password, HashMap attributes, boolean consistent) throws IOException, ChinoApiException {
+        return update(false, userId, username, password, attributes, consistent);
+    }
+
+    /**
+     * Update a {@link User} object.
+     *
+     * @param activateResource if true, the update method will set {@code "is_active": true} in the resource.
+     *                         Otherwise, the value of is_active will not be modified.
+     * @param userId the User's ID on Chino.io
+     * @param username the username of the User
+     * @param password the password of the User
+     * @param attributes an HashMap with the new values of the User's attributes.
+     *                   You must provide <b><i> all </i></b> of the attributes that are defined for the User.
+     * @param consistent setting this flag to {@code true} will make the indexing synchronous with the creation of the user,
+     *                   i.e. search operations will be successful right after this method returns.
+     *                   However, this operation has a cost and can make the API call last for seconds before answering.
+     *                   Use only when it's really needed
+     *
+     *
+     * @return the updated {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    @Nullable
+    public User update(boolean activateResource, String userId, String username, String password, HashMap attributes, boolean consistent) throws IOException, ChinoApiException {
         checkNotNull(userId, "user_id");
         CreateUserRequest createUserRequest= new CreateUserRequest(username, password, attributes);
+
+        if (activateResource)
+            createUserRequest.activateResource();
 
         String URL = "/users/"+userId + ((consistent) ? "?consistent=true" : "");
         JsonNode data = putResource(URL, createUserRequest);
@@ -398,7 +548,7 @@ public class Users extends ChinoBaseAPI {
      */
     @Nullable
     public User update(String userId, String username, String password, String attributes) throws IOException, ChinoApiException {
-        return update(userId, username, password, attributes, false);
+        return update(false, userId, username, password, attributes, false);
     }
 
     /**
@@ -415,9 +565,58 @@ public class Users extends ChinoBaseAPI {
      * @throws ChinoApiException server error
      */
     @Nullable
+    public User update(boolean activateResource, String userId, String username, String password, String attributes) throws IOException, ChinoApiException {
+        return update(activateResource, userId, username, password, attributes, false);
+    }
+
+    /**
+     * Update a {@link User} object.
+     *
+     * @param userId the User's ID on Chino.io
+     * @param username the username of the User
+     * @param password the password of the User
+     * @param attributes a JSON object (as a {@link String}) with the new values of the User's attributes
+     * @param consistent setting this flag to {@code true} will make the indexing synchronous with the creation of the
+     *                   user,
+     *                   i.e. search operations will be successful right after this method returns.
+     *                   However, this operation has a cost and can make the API call last for seconds before answering.
+     *                   Use only when it's really needed
+     *
+     * @return the updated {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    @Nullable
     public User update(String userId, String username, String password, String attributes, boolean consistent) throws IOException, ChinoApiException {
+        return update(false, userId, username, password, attributes, consistent);
+    }
+
+    /**
+     * Update a {@link User} object.
+     *
+     * @param userId the User's ID on Chino.io
+     * @param username the username of the User
+     * @param password the password of the User
+     * @param attributes a JSON object (as a {@link String}) with the new values of the User's attributes
+     * @param consistent setting this flag to {@code true} will make the indexing synchronous with the creation of the
+     *                   user,
+     *                   i.e. search operations will be successful right after this method returns.
+     *                   However, this operation has a cost and can make the API call last for seconds before answering.
+     *                   Use only when it's really needed
+     *
+     * @return the updated {@link User} object
+     *
+     * @throws IOException data processing error
+     * @throws ChinoApiException server error
+     */
+    @Nullable
+    public User update(boolean activateResource, String userId, String username, String password, String attributes, boolean consistent) throws IOException, ChinoApiException {
         checkNotNull(userId, "user_id");
         CreateUserRequest createUserRequest= new CreateUserRequest(username, password, fromStringToHashMap(attributes));
+
+        if (activateResource)
+            createUserRequest.activateResource();
 
         String URL = "/users/"+userId + ((consistent) ? "?consistent=true" : "");
         JsonNode data = putResource(URL, createUserRequest);

--- a/src/test/java/io/chino/java/CollectionsTest.java
+++ b/src/test/java/io/chino/java/CollectionsTest.java
@@ -166,7 +166,7 @@ public class CollectionsTest extends ChinoBaseTest {
     }
 
     @Test
-    public void testActivate() throws IOException, ChinoApiException {
+    public void test_activate() throws IOException, ChinoApiException {
         Collection coll = test.create("test_activation");
         String id = coll.getCollectionId();
         // Set is_active = false

--- a/src/test/java/io/chino/java/CollectionsTest.java
+++ b/src/test/java/io/chino/java/CollectionsTest.java
@@ -165,6 +165,26 @@ public class CollectionsTest extends ChinoBaseTest {
         );
     }
 
+    @Test
+    public void testActivate() throws IOException, ChinoApiException {
+        Collection coll = test.create("test_activation");
+        String id = coll.getCollectionId();
+        // Set is_active = false
+        test.delete(id, false);
+        assertFalse("Failed to set inactive", test.read(id).getIsActive());
+        // Set is_active = true
+        test.update(true, id, "test_activation_updated");
+        Collection control = test.read(id);
+        // Verify update
+        assertTrue("Failed to activate", control.getIsActive());
+        assertNotEquals("Failed to update after activation",
+                coll.getName(),
+                control.getName()
+        );
+
+        test.delete(id, true);
+    }
+
     private Document newDoc(String docTitle) throws IOException, ChinoApiException {
         HashMap<String, String> content = new HashMap<>();
         content.put("title", docTitle);

--- a/src/test/java/io/chino/java/ConsentsTest.java
+++ b/src/test/java/io/chino/java/ConsentsTest.java
@@ -11,10 +11,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.LinkedList;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
@@ -24,30 +21,30 @@ import static org.junit.Assert.*;
  * @author Andrea Arighi [andrea@chino.io]
  */
 public class ConsentsTest extends ChinoBaseTest {
-    
+
     private static ChinoAPI chino_admin;
     private static Consents test;
     private static ArrayList<Consent> createdObjects;
-    
+
     private static String userId1 = "mariorossi@mailmail.com",
             userId2 = "rossimario@mail.ml";
-    
+
     /**
     * User Id value for testDeleted* methods.
     */
     private String deletedUserId = "userIdDelete@mail.ml";
-    
+
     /**
      * consentId of the deleted Consent will be stored here.
      * Used for testDeleted* methods.
      */
     private String deletedConsentId = null;
-    
+
     private static DataController dcSample;
     private static Purpose pSample1, pSample2, pSample3;
     private static Consent consentSample1 = null,
             consentSample2 = null;
-   
+
     @BeforeClass
     public static void setUpClass() throws IOException, ChinoApiException {
         ChinoBaseTest.beforeClass();
@@ -56,9 +53,9 @@ public class ConsentsTest extends ChinoBaseTest {
         ChinoBaseTest.checkResourceIsEmpty(test.list().getConsents().isEmpty(), test);
 
         createdObjects = new ArrayList<>();
-        
+
         dcSample = new DataController("Chino.io", "example", "42 John Doe St.", "java-example@chino.io", "vat123456789", true);
-        
+
         pSample1 = new Purpose(true, "promo", "Send ads to mail and address");
         pSample2  = new Purpose(false, "third-party", "Send data to third party services");
         pSample3 = new Purpose(true, "internal", "Internal usage");
@@ -66,21 +63,21 @@ public class ConsentsTest extends ChinoBaseTest {
         purposes.add(pSample1);
         purposes.add(pSample2);
         purposes.add(pSample3);
-        
+
         // creating sample consent for "mariorossi@mailmail.com".
         // Local object, not on Chino.io
         consentSample1 = new Consent(userId1, "Consent sample created for testing - class ConsentsTest"  + " [" + TestConstants.JAVA + "]",
                 "https://www.chino.io/legal/privacy-policy", "v1.0", "web-form", dcSample, purposes);
         System.out.println(consentSample1.getConsentId());
-        
+
         purposes.remove(pSample1);
         purposes.remove(pSample2);
-        
+
         // creating sample consent for another user, "rossimario@mail.ml",
         // with different purposes. Local object, not on Chino.io
         consentSample2 = new Consent(new Consent(consentSample1, null, purposes), userId2);
     }
-    
+
     @Before
     @After
     public void deleteCreatedObjects() {
@@ -101,7 +98,7 @@ public class ConsentsTest extends ChinoBaseTest {
         int size = createdObjects.size() -  deletedObjects.size();
         if (size > 0)
             System.out.println(String.format("*** Unable to delete %s objects.***", size));
-        
+
         createdObjects.clear();
     }
 
@@ -111,7 +108,7 @@ public class ConsentsTest extends ChinoBaseTest {
     @Test
     public void testList_3args() throws Exception {
         System.out.println("list (3 args)");
-        
+
         int newValidConsents = 4;
         String userId = "userIdList3@mail.ml";
         for (int i = 0; i<newValidConsents; i++) {
@@ -119,14 +116,14 @@ public class ConsentsTest extends ChinoBaseTest {
                     test.create(consentSample1, userId)
             );
         }
-        
+
         createdObjects.add(
                 test.create(consentSample1, "ignoredUserId@mail.ml")
         );
         createdObjects.add(
                 test.create(consentSample1, "anotherIgnoredUserId@mail.ml")
         );
-        
+
         int totalListElements = 0;
         int limit = 2;
         for (int i=0; i < (newValidConsents + limit - 1)/limit; i++) {
@@ -151,7 +148,7 @@ public class ConsentsTest extends ChinoBaseTest {
     @Test
     public void testList_int_int() throws Exception {
         System.out.println("list (2 args)");
-        
+
         int newConsents = 7;
         String userId = "userIdList2@mail.ml";
         for (int i = 0; i<newConsents; i++) {
@@ -159,7 +156,7 @@ public class ConsentsTest extends ChinoBaseTest {
                     test.create(consentSample1, userId)
             );
         }
-        
+
         int totalListElements = 0;
         int limit = 2;
         for (int offset = 0; offset < newConsents; offset += limit) {
@@ -189,7 +186,7 @@ public class ConsentsTest extends ChinoBaseTest {
         createdObjects.addAll(
                 test.list(userId, 0, ChinoApiConstants.QUERY_DEFAULT_LIMIT)
         );
-        
+
         // Tested method
         ConsentList results = test.list();
         assertEquals(createdObjects.size(), results.size());
@@ -208,7 +205,7 @@ public class ConsentsTest extends ChinoBaseTest {
         createdObjects.add(local);
         assertNotNull(local.getUserId());
         assertNotNull(local.getConsentId());
-        
+
         Consent fetched = test.list(userId, 0, 1).get(0);
         assertNotNull("Couldn't retrieve created object", fetched);
         assertNotNull("Retrieved object has no consentId", fetched.getConsentId());
@@ -222,7 +219,7 @@ public class ConsentsTest extends ChinoBaseTest {
     public void testCreate_7args() throws Exception {
         System.out.println("create (7 args)");
         System.out.println("(Tested during setUpClass)");
-        
+
         assertNotNull(consentSample1);
     }
 
@@ -232,7 +229,7 @@ public class ConsentsTest extends ChinoBaseTest {
     @Test
     public void testCreate_3args() throws Exception {
         System.out.println("create (3 args)");
-        
+
         String userId = "userIdCreate3Args@mail.ml";
         Consent base = new Consent(consentSample1, userId);
         DataController newDataController = new DataController("new company", "new contact", "new address", "new_email@mail.ml", "new VAT", true);
@@ -241,7 +238,7 @@ public class ConsentsTest extends ChinoBaseTest {
         // Test method
         Consent consent = test.create(consentSample2, newDataController, newPurposes);
         createdObjects.add(consent);
-        
+
         assertNotNull(consent.getConsentId());
         assertEquals(1, consent.getPurposes().size());
         assertNotNull(consent.getDataController());
@@ -262,12 +259,12 @@ public class ConsentsTest extends ChinoBaseTest {
     @Test
     public void testCreate_Consent_String() throws Exception {
         System.out.println("create (2 args)");
-        
+
         String userId = "userIdCreate2Args@mail.ml";
-        
+
         Consent consent1 = test.create(consentSample2, userId);
         createdObjects.add(consent1);
-        
+
         assertNotNull(consent1.getUserId());
         assertFalse(consent1.getUserId().isEmpty());
     }
@@ -280,10 +277,10 @@ public class ConsentsTest extends ChinoBaseTest {
         System.out.println("read");
 
         String userId = "userIdRead@mail.ml";
-        
+
         Consent consent1 = test.create(new Consent(consentSample2, userId));
         createdObjects.add(consent1);
-        
+
         assertNotNull("failed to read consent 1", test.read(consent1.getConsentId()));
     }
 
@@ -297,7 +294,7 @@ public class ConsentsTest extends ChinoBaseTest {
         System.out.println("update");
         String userId = "userIdCreate@mail.ml";
         Consent base = new Consent(consentSample1, userId);
-        
+
         Consent consentOld = test.create(base);
         createdObjects.add(consentOld);
         long waitingTime = 5;
@@ -313,14 +310,14 @@ public class ConsentsTest extends ChinoBaseTest {
         assertNotEquals(consentUpdated.getDataController(), updatedDataController);
         assertNotEquals(consentUpdated.getPurposes(), consentOld.getPurposes());
         TimeUnit.SECONDS.sleep(waitingTime);
-        
+
         System.out.println("history");
         // Test method (history)
         ConsentHistory history = test.history(consentOld.getConsentId());
         assertFalse(history.isEmpty());
         assertEquals(consentUpdated, history.getActiveConsent());
         assertEquals(consentOld.getConsentId(), history.getConsentId());
-        
+
         Consent consentOldInHistory = null;
         for (Consent c:history) {
             if (c.isWithdrawn()) {
@@ -334,7 +331,7 @@ public class ConsentsTest extends ChinoBaseTest {
             consentOldInHistory
         );
         assertEquals(consentOldInHistory, consentOld);
-        
+
         Consent test1 = history.getActiveConsentOnDate(consentOld.getInsertedDate());
         System.out.println("TEST1: inserted " + test1.getInsertedDate() + ", removed: " + test1.getWithdrawnDate());
         System.out.println(history.getActiveConsentOnDate(new Date(((long) 1000))));
@@ -352,7 +349,7 @@ public class ConsentsTest extends ChinoBaseTest {
         // get the Consent that is active now (i.e. consentUpdated)
         assertEquals(history.getActiveConsentOnDate(new Date()), consentUpdated);
     }
-    
+
     /**
      * Test of the Exception that should be thrown by
  {@link ConsentHistory#getActiveConsentOnDate(java.util.Date) getActiveConsentOnDate}
@@ -363,7 +360,7 @@ public class ConsentsTest extends ChinoBaseTest {
         String userId = "userIdhistory_findVersion_Exception@mail.ml";
         Consent created = test.create(consentSample1, userId);
         createdObjects.add(created);
-        
+
         ConsentHistory history = test.history(created.getConsentId());
         // this call should throw an Exception
         Calendar cal = Calendar.getInstance();
@@ -380,16 +377,16 @@ public class ConsentsTest extends ChinoBaseTest {
     @Test
     public void testWithdraw() throws Exception {
         System.out.println("withdraw");
-        
+
         String userId = "userIdWithdraw@mail.ml";
         test.create(consentSample1, userId);
         Consent c = test.list(userId, 0, 1).get(0);
         createdObjects.add(c);
-        
+
         // Test method
         test.withdraw(c.getConsentId());
         assertTrue(test.read(c.getConsentId()).isWithdrawn());
-        
+
         // Check that c is still returned by history() but that it's not recognized as 'active'
         ConsentHistory h = test.history(c.getConsentId());
         assertFalse(h.isEmpty());
@@ -398,42 +395,43 @@ public class ConsentsTest extends ChinoBaseTest {
     }
 
     /**
-     * Test of delete method, of class Consents.
+     * Prepare tests of delete() method of class Consents.
      */
     public void deleteInit() throws Exception {
-        System.out.println("delete");
         if (deletedConsentId != null)
             return;
-        
-        
+        // create a Consent that will be deleted
         Consent c = test.create(consentSample1, deletedUserId);
         createdObjects.add(c);
         deletedConsentId = c.getConsentId();
-        
-        // Test method
+        // Test delete() method
         test.delete(deletedConsentId);
         createdObjects.remove(c);
     }
-    
+
     @Test(expected = ChinoApiException.class)
-    public void testDeletedRead() throws Exception {
+    public void testRead_DeletedConsent() throws Exception {
         deleteInit();
-        System.out.println("delete (read)");
+        System.out.println("read deleted Consent (expect Exception)");
         test.read(deletedConsentId);
     }
-    
+
     @Test(expected = ChinoApiException.class)
-    public void testDeletedHistory() throws Exception {
+    public void testHistory_DeletedConsent() throws Exception {
         deleteInit();
-        System.out.println("delete (history)");
+        System.out.println("history of deleted Consent (expect Exception)");
         test.history(deletedConsentId);
     }
-    
+
     @Test
-    public void testDeletedList() throws Exception {
+    public void testList_DeletedConsents() throws Exception {
         deleteInit();
-        System.out.println("delete (list)");
-        assertTrue(test.list(deletedUserId, 0, ChinoApiConstants.QUERY_DEFAULT_LIMIT).isEmpty());
+        System.out.println("list of Consents of a deleted User (expect empty list)");
+        List<Consent> ls = test.list(deletedUserId, 0, ChinoApiConstants.QUERY_DEFAULT_LIMIT).getConsents();
+        assertTrue(
+                String.format("List of Consents is not empty for a deleted User. %s Consents found", ls.size()),
+                ls.isEmpty()
+        );
     }
-    
+
 }

--- a/src/test/java/io/chino/java/DocumentsTest.java
+++ b/src/test/java/io/chino/java/DocumentsTest.java
@@ -252,6 +252,57 @@ public class   DocumentsTest extends ChinoBaseTest {
         test.delete(doc.getDocumentId(), true);
     }
 
+    @Test
+    public void testActivate() throws Exception {
+        Document doc1 = newDoc("testActivate1");
+        Document doc2 = newDoc("testActivate2");
+        String id1 = doc1.getDocumentId();
+        String id2 = doc2.getDocumentId();
+        // Set is_active = false
+        test.delete(id1, false);
+        test.delete(id2, false);
+        assertFalse("Failed to set Document 1 inactive", test.read(id1).getIsActive());
+        assertFalse("Failed to set Document 2 inactive", test.read(id2).getIsActive());
+
+        // Set is_active = true
+        HashMap<String, String> content1 = new HashMap<>();
+        content1.put("testMethod", "test_activation_updated");
+        test.update(true, id1, content1);      // method 1: (String, HashMap)
+        Document control1 = test.read(id1);
+
+        String content2 = "{" +
+                    "\"testMethod\": \"test_activation_updated\"" +
+                "}";
+        test.update(true, id2, content2);      // method 2: (String, String)
+        Document control2 = test.read(id2);
+
+        // Verify update
+        assertTrue("Failed to activate Document 1", control1.getIsActive());
+        assertNotEquals("Failed to update Document 1 after activation",
+                doc1.getContentAsHashMap().get("testMethod"),
+                control1.getContentAsHashMap().get("testMethod")
+        );
+        assertTrue("Failed to activate Document 2", control2.getIsActive());
+        assertNotEquals("Failed to update Document 2 after activation",
+                doc2.getContentAsHashMap().get("testMethod"),
+                control2.getContentAsHashMap().get("testMethod")
+        );
+        Exception[] errors = new Exception[2];
+        try {
+            test.delete(id1, true);
+            errors[0] = null;
+        } catch (IOException | ChinoApiException e1){
+            errors[0] = e1;
+        }
+        try {
+            test.delete(id2, true);
+        } catch (IOException | ChinoApiException e2){
+            errors[1] = e2;
+        }
+        if (errors[0] != null) throw errors[0];
+        if (errors[1] != null) throw errors[1];
+    }
+
 
     private Document newDoc(String methodName) throws IOException, ChinoApiException {
         HashMap<String, String> content = new HashMap<>();

--- a/src/test/java/io/chino/java/GroupsTest.java
+++ b/src/test/java/io/chino/java/GroupsTest.java
@@ -164,6 +164,33 @@ public class GroupsTest extends ChinoBaseTest {
 //        );
     }
 
+
+
+    @Test
+    public void testActivate() throws IOException, ChinoApiException {
+        Group group = test.create("test_activation", new HashMap());
+        String id = group.getGroupId();
+        // Set is_active = false
+        test.delete(id, false);
+        assertFalse("Failed to set inactive", test.read(id).getIsActive());
+        // Set is_active = true
+        HashMap<String, Object> attributes = new HashMap<>();
+        attributes.put("updated", true);
+        test.update(true, id, "test_activation_updated", attributes);
+        Group control = test.read(id);
+        // Verify update
+        assertTrue("Failed to activate", control.getIsActive());
+        assertNotEquals("Failed to update after activation",
+                group.getGroupName(),
+                control.getGroupName()
+        );
+        assertTrue("Failed to add attributes after activation",
+                control.getAttributes().has("updated")
+        );
+
+        test.delete(id, true);
+    }
+
     private static void assertUserIsIn(User user, Group group) throws IOException, ChinoApiException {
         User check = chino_admin.users.read(user.getUserId());
         List groups = check.getGroups();

--- a/src/test/java/io/chino/java/RepositoriesTest.java
+++ b/src/test/java/io/chino/java/RepositoriesTest.java
@@ -107,6 +107,26 @@ public class RepositoriesTest extends ChinoBaseTest {
         );
     }
 
+    @Test
+    public void test_activate() throws IOException, ChinoApiException {
+        Repository repo = test.create("test_activation");
+        String id = repo.getRepositoryId();
+        // Set is_active = false
+        test.delete(id, false);
+        assertFalse("Failed to set inactive", test.read(id).getIsActive());
+        // Set is_active = true
+        test.update(true, id, "test_activation_updated");
+        Repository control = test.read(id);
+        // Verify update
+        assertTrue("Failed to activate", control.getIsActive());
+        assertNotEquals("Failed to update after activation",
+                repo.getDescription(),
+                control.getDescription()
+        );
+
+        test.delete(id, true);
+    }
+
     @AfterClass
     public static void afterClass() throws IOException, ChinoApiException {
         new DeleteAll().deleteAll(test);

--- a/src/test/java/io/chino/java/SchemasTest.java
+++ b/src/test/java/io/chino/java/SchemasTest.java
@@ -141,6 +141,27 @@ public class SchemasTest extends ChinoBaseTest {
         );
     }
 
+    @Test
+    public void test_activate() throws IOException, ChinoApiException {
+        Schema schema = makeSchema("test_activation", 1);
+        String id = schema.getSchemaId();
+        // Set is_active = false
+        test.delete(id, false);
+        assertFalse("Failed to set inactive", test.read(id).getIsActive());
+        // Set is_active = true
+        // only need to test for one method - other methods
+        test.update(true, id, "test_activation_updated", schema.getStructure());
+        Schema control = test.read(id);
+        // Verify update
+        assertTrue("Failed to activate", control.getIsActive());
+        assertNotEquals("Failed to update after activation",
+                schema.getDescription(),
+                control.getDescription()
+        );
+
+        test.delete(id, true);
+    }
+
     private synchronized Schema makeSchema(String method, int instanceNumber) throws IOException, ChinoApiException {
         String desc = method + "_" + instanceNumber;
 


### PR DESCRIPTION
## Re-activation
When a resource is deactivated with `force=false`

	delete(id, false)

Now it can be re-activated with an `update()`:

	update(true, ...)

---

This change affects:

* Collections
* Documents
* Groups
* Repositories
* Schemas
* Users
* UserSchemas

## Deactivation
Deprecated invalid delete methods for resources that **can't be deactivated**:

```java
    @Deprecated
    public String delete(String resourceId, boolean force)
```

This change affects:

* Applications
* BLOBs